### PR TITLE
Add structured laboratory studies (laboratory-tests-v1) with editor, catalog and comparison

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 ## Validation
 
 - The Compose end-to-end suite (`npm run test:e2e:compose`) must pass for every change.
-- Codecov patch coverage must be at least 90% for every change. Add or extend tests until the `codecov/patch` check meets this target; do not lower the target or make the check informational.
+- Codecov patch coverage—the coverage of executable lines added or modified by the current change—must be at least 90% for every change. This is distinct from overall project coverage: a passing `codecov/project` check or a high repository-wide percentage does not satisfy this requirement. Add or extend tests until the `codecov/patch` check meets the target; do not lower the target or make the check informational.
 
 ## Shared UI components
 

--- a/api-node/src/commands.spec.ts
+++ b/api-node/src/commands.spec.ts
@@ -55,6 +55,20 @@ async function confirmVaccinationAgainst(current: { confirmed: unknown; profile:
 }
 
 describe("command boundary", () => {
+  it("silently omits legacy free-text laboratory sections", () => {
+    const result = validateMedicalEncounter({
+      petId: "pet-1",
+      encounterDate: "2026-08-10",
+      sections: {
+        "what-happened": { selectedIds: ["problem.digestive.1"], comment: "Не ест" },
+        "laboratory-tests": { text: "Старый лабораторный текст" },
+        outcome: { selectedIds: ["outcome.observation"], comment: "" },
+      },
+    });
+
+    expect(result.sections["laboratory-tests"]).toBeUndefined();
+  });
+
   it("validates structured diagnosis catalog and free-form representations", () => {
     const input = {
       petId: "pet-1",

--- a/api-node/src/commands.ts
+++ b/api-node/src/commands.ts
@@ -187,16 +187,14 @@ export function validateMedicalEncounter(value: unknown): MedicalEncounterInput 
       && (typeof structured.text !== "string" || !structured.text.trim() || structured.text.length > 50_000)) {
       throw new ApiError(400, "VALIDATION_FAILED", `The ${kind} section is invalid.`);
     }
-    if (kind === "laboratory-tests" && "text" in structured
-      && (typeof structured.text !== "string" || !structured.text.trim() || structured.text.length > 50_000)) {
-      throw new ApiError(400, "VALIDATION_FAILED", "The laboratory-tests section is invalid.");
-    }
   }
+  const currentSections = Object.fromEntries(Object.entries(sections).filter(([kind, value]) =>
+    kind !== "laboratory-tests" || !("text" in object(value))));
   return {
     petId: requireText(input.petId, "petId", 100),
     encounterDate,
     sections: {
-      ...sections,
+      ...currentSections,
       ...(sections["laboratory-tests"] && !("text" in object(sections["laboratory-tests"]))
         ? { "laboratory-tests": laboratorySection(sections["laboratory-tests"]) } : {}),
       ...(diagnosis ? { diagnosis } : {}),

--- a/api-node/src/commands.ts
+++ b/api-node/src/commands.ts
@@ -9,6 +9,7 @@ import {
   isDiagnosisTaxonomyId,
   isOutcomeTaxonomyId,
   isWhatHappenedTaxonomyId,
+  normalizeLaboratoryTestsValue,
   type ClientCommand,
   type CommandResult,
   type DiagnosisChoice,
@@ -182,9 +183,13 @@ export function validateMedicalEncounter(value: unknown): MedicalEncounterInput 
   for (const [kind, sectionValue] of Object.entries(sections)) {
     if (kind === "what-happened" || kind === "outcome" || kind === "diagnosis") continue;
     const structured = object(sectionValue);
-    if (["recommendations", "laboratory-tests", "instrumental-tests", "procedures"].includes(kind)
+    if (["recommendations", "instrumental-tests", "procedures"].includes(kind)
       && (typeof structured.text !== "string" || !structured.text.trim() || structured.text.length > 50_000)) {
       throw new ApiError(400, "VALIDATION_FAILED", `The ${kind} section is invalid.`);
+    }
+    if (kind === "laboratory-tests" && "text" in structured
+      && (typeof structured.text !== "string" || !structured.text.trim() || structured.text.length > 50_000)) {
+      throw new ApiError(400, "VALIDATION_FAILED", "The laboratory-tests section is invalid.");
     }
   }
   return {
@@ -192,6 +197,8 @@ export function validateMedicalEncounter(value: unknown): MedicalEncounterInput 
     encounterDate,
     sections: {
       ...sections,
+      ...(sections["laboratory-tests"] && !("text" in object(sections["laboratory-tests"]))
+        ? { "laboratory-tests": laboratorySection(sections["laboratory-tests"]) } : {}),
       ...(diagnosis ? { diagnosis } : {}),
     } as unknown as MedicalEncounterInput["sections"],
     ...(input.recordId ? { recordId: requireText(input.recordId, "recordId", 100) } : {}),
@@ -207,12 +214,18 @@ function medicalSections(input: MedicalEncounterInput, accountId: string, author
         : kind === "general-data" && !(value && typeof value === "object" && "text" in value) ? "general-data-v1"
           : kind === "vaccination" && !(value && typeof value === "object" && "text" in value) ? "vaccination-v1"
             : kind === "therapeutic-appointment" && !(value && typeof value === "object" && "text" in value) ? "therapeutic-appointment-v1"
+              : kind === "laboratory-tests" && !(value && typeof value === "object" && "text" in value) ? "laboratory-tests-v1"
               : "free-text-v0",
     value,
     authorAccountId: accountId,
     authorDisplayName: authorName,
     updatedAt: now,
   }])) as MedicalRecordDraft["sections"];
+}
+
+function laboratorySection(value: unknown) {
+  try { return normalizeLaboratoryTestsValue(value); }
+  catch (reason) { throw new ApiError(400, "VALIDATION_FAILED", reason instanceof Error ? reason.message : "The laboratory section is invalid."); }
 }
 
 function medicalRecordAuditState(

--- a/api-node/src/rows.spec.ts
+++ b/api-node/src/rows.spec.ts
@@ -3,11 +3,33 @@
 // This file is a part of Klinok application
 
 import { describe, expect, it } from "vitest";
-import { dateOnly } from "./rows.js";
+import { dateOnly, recordFromRow } from "./rows.js";
 
 describe("PostgreSQL row conversion", () => {
   it("preserves date-only values returned as strings or local Date objects", () => {
     expect(dateOnly("2022-06-17")).toBe("2022-06-17");
     expect(dateOnly(new Date(2022, 5, 17))).toBe("2022-06-17");
+  });
+
+  it("silently omits legacy free-text laboratory sections", () => {
+    const record = recordFromRow({
+      record_id: "record-1",
+      pet_id: "pet-1",
+      revision: 1,
+      author_account_id: "doctor-1",
+      author_display_name: "Иван Врач",
+      encounter_date: "2026-08-15",
+      title: "Приём",
+      text: "Осмотр",
+      sections: {
+        "what-happened": { templateVersion: "what-happened-v1", value: { selectedIds: [], comment: "Осмотр" } },
+        "laboratory-tests": { templateVersion: "free-text-v0", value: { text: "Старый лабораторный текст" } },
+      },
+      created_at: "2026-08-15T10:00:00.000Z",
+      updated_at: "2026-08-15T10:00:00.000Z",
+    });
+
+    expect(record.sections["laboratory-tests"]).toBeUndefined();
+    expect(record.sections["what-happened"]).toBeDefined();
   });
 });

--- a/api-node/src/rows.ts
+++ b/api-node/src/rows.ts
@@ -114,6 +114,8 @@ export function grantFromRow(row: Record<string, unknown>): PetAccessGrant {
 }
 
 export function recordFromRow(row: Record<string, unknown>): MedicalRecordDraft {
+  const sections = { ...(row.sections as MedicalRecordDraft["sections"]) };
+  if (sections["laboratory-tests"]?.templateVersion === "free-text-v0") delete sections["laboratory-tests"];
   return {
     recordId: String(row.record_id),
     petId: String(row.pet_id),
@@ -123,7 +125,7 @@ export function recordFromRow(row: Record<string, unknown>): MedicalRecordDraft 
     encounterDate: dateOnly(row.encounter_date as Date | string),
     title: String(row.title),
     text: String(row.text),
-    sections: row.sections as MedicalRecordDraft["sections"],
+    sections,
     createdAt: iso(row.created_at as Date | string),
     updatedAt: iso(row.updated_at as Date | string),
   };

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -3,6 +3,7 @@
 // This file is a part of Klinok application
 
 import type { DiagnosisSectionValue } from "./diagnosis.js";
+import type { LaboratoryTestsSectionValue } from "./laboratory.js";
 
 export {
   DIAGNOSIS_CATALOG,
@@ -16,6 +17,18 @@ export {
   type DiagnosisSectionValue,
   type DiagnosisTaxonomyId,
 } from "./diagnosis.js";
+export {
+  LABORATORY_STUDY_CATALOG,
+  LABORATORY_STUDY_OPTIONS,
+  laboratoryIndicatorById,
+  laboratoryStudyTypeById,
+  normalizeLaboratoryTestsValue,
+  type LaboratoryIndicatorCatalogItem,
+  type LaboratoryPanelStudyValue,
+  type LaboratoryStudyValue,
+  type LaboratoryTestsSectionValue,
+  type LaboratoryStudyTypeCatalogItem,
+} from "./laboratory.js";
 
 export const ROLES = ["administrator", "doctor", "owner"] as const;
 export type Role = (typeof ROLES)[number];
@@ -307,8 +320,8 @@ export interface TherapeuticAppointmentSectionValue {
 
 export interface MedicalEncounterSection {
   kind: MedicalEncounterSectionKind;
-  templateVersion: "what-happened-v1" | "outcome-v1" | "diagnosis-v1" | "diagnosis-v2" | "general-data-v1" | "vaccination-v1" | "therapeutic-appointment-v1" | "free-text-v0";
-  value: WhatHappenedSectionValue | OutcomeSectionValue | DiagnosisSectionValue | GeneralDataSectionValue | VaccinationSectionValue | TherapeuticAppointmentSectionValue | FreeTextSectionValue;
+  templateVersion: "what-happened-v1" | "outcome-v1" | "diagnosis-v1" | "diagnosis-v2" | "general-data-v1" | "vaccination-v1" | "therapeutic-appointment-v1" | "laboratory-tests-v1" | "free-text-v0";
+  value: WhatHappenedSectionValue | OutcomeSectionValue | DiagnosisSectionValue | GeneralDataSectionValue | VaccinationSectionValue | TherapeuticAppointmentSectionValue | LaboratoryTestsSectionValue | FreeTextSectionValue;
   authorAccountId: string;
   authorDisplayName: string;
   updatedAt: string;

--- a/packages/contracts/src/laboratory.ts
+++ b/packages/contracts/src/laboratory.ts
@@ -1,0 +1,68 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Klinok application
+
+export type LaboratoryStudyMode = "panel" | "narrative" | "infection";
+export interface LaboratoryIndicatorCatalogItem { readonly id: string; readonly name: string; readonly unit: string }
+export interface LaboratoryStudyTypeCatalogItem {
+  readonly id: string; readonly name: string; readonly mode: LaboratoryStudyMode;
+  readonly indicators: readonly LaboratoryIndicatorCatalogItem[];
+}
+interface LaboratoryStudyBase { id: string; date: string; typeId: string; typeName: string; laboratory: string; technician?: string; equipment?: string; comment?: string }
+export interface LaboratoryPanelStudyValue extends LaboratoryStudyBase { mode: "panel"; results: readonly { indicatorId: string; indicatorName: string; unit: string; result: string; reference?: string }[] }
+export interface LaboratoryNarrativeStudyValue extends LaboratoryStudyBase { mode: "narrative"; result: string }
+export interface LaboratoryInfectionStudyValue extends LaboratoryStudyBase { mode: "infection"; infection: string; method: "ПЦР" | "ИФА" | "РМА" | "ELISA" | "ИХА"; result: "positive" | "negative" }
+export type LaboratoryStudyValue = LaboratoryPanelStudyValue | LaboratoryNarrativeStudyValue | LaboratoryInfectionStudyValue;
+export interface LaboratoryTestsSectionValue { studies: readonly LaboratoryStudyValue[] }
+
+function indicators(prefix: string, rows: readonly (readonly [string, string])[]): LaboratoryIndicatorCatalogItem[] {
+  return rows.map(([name, unit], index) => ({ id: `lab.indicator.${prefix}.${String(index + 1).padStart(3, "0")}`, name, unit }));
+}
+const cbc = indicators("cbc", [
+  ["Гематокрит (Hct, PCV)", "%"], ["Гемоглобин (Hgb)", "г/л"], ["Эритроциты (RBC)", "×10¹²/л"], ["Лейкоциты (WBC)", "×10⁹/л"], ["Тромбоциты (Plt)", "×10⁹/л"], ["Количество тромбоцитов в п/зр.", "в п/зр (HPF)"], ["Ядерные эритроциты (нормобласты, nRBC)", "на 100 лейкоцитов"], ["Анизоцитоз эритроцитов (RDW-CV)", "%"], ["Ретикулоциты", "%"], ["Ретикулоциты", "×10⁹/л"], ["Ретикулоциты агрегатные", "%"], ["Ретикулоциты агрегатные", "×10⁹/л"], ["Ретикулоциты пунктатные", "%"], ["Ретикулоциты пунктатные", "×10⁹/л"], ["Средняя конц. Hb в эритроците (MCHC)", "г/дл"], ["Средний объем эритроцита (MCV)", "мкм³ (фл)"], ["Среднее содержание Hb в эритроците (MCH)", "пг"], ["Бластные клетки", "%"], ["Бластные клетки", "×10⁹/л"], ["Миелоциты", "%"], ["Миелоциты", "×10⁹/л"], ["Метамиелоциты", "%"], ["Метамиелоциты", "×10⁹/л"], ["Палочкоядерные нейтрофилы (Bands)", "%"], ["Палочкоядерные нейтрофилы ABS", "×10⁹/л"], ["Сегментоядерные нейтрофилы (Segs)", "%"], ["Сегментоядерные нейтрофилы ABS", "×10⁹/л"], ["Эозинофилы (Eos)", "%"], ["Эозинофилы ABS", "×10⁹/л"], ["Моноциты (Mono)", "%"], ["Моноциты ABS", "×10⁹/л"], ["Базофилы (Bas)", "%"], ["Базофилы ABS", "×10⁹/л"], ["Лимфоциты (Lym)", "%"], ["Лимфоциты ABS", "×10⁹/л"],
+]);
+const biochemistry = indicators("biochemistry", [
+  ["Билирубин общий (TBil)", "мкмоль/л"], ["Билирубин прямой (DBil)", "мкмоль/л"], ["АСТ (GOT)", "Ед/л"], ["АЛТ (GPT)", "Ед/л"], ["Мочевина (Urea)", "ммоль/л"], ["Креатинин (Creat)", "мкмоль/л"], ["Общий белок (Prot, total)", "г/л"], ["Альбумин (Alb)", "г/л"], ["Глобулин (Glob)", "г/л"], ["Щелочная фосфатаза (ALP, IFCC)", "Ед/л"], ["Альфа-Амилаза, общая", "Ед/л"], ["Глюкоза (Glu)", "ммоль/л"], ["ЛДГ (LDH, IFCC)", "Ед/л"], ["ГГТ (γ-GT, IFCC)", "Ед/л"], ["Холестерин (Chol, total)", "ммоль/л"], ["Триглицериды (Trig)", "ммоль/л"], ["КФК (CK)", "Ед/л"], ["Калий (Potassium)", "ммоль/л"], ["Натрий (Sodium)", "ммоль/л"], ["Фосфор (Phosphate, inorg)", "ммоль/л"], ["Кальций общий (Ca, total)", "ммоль/л"], ["Кальций ионизированный (iCa)", "ммоль/л"], ["Железо (Fe)", "мкмоль/л"], ["Магний (Mg)", "ммоль/л"], ["Хлор (Chloride)", "ммоль/л"], ["Мочевая кислота (Uric Acid)", "мкмоль/л"], ["Кислая фосфатаза (ACP, total)", "Ед/л"], ["Холинэстераза (ChE, GSCC)", "Ед/л"], ["Липаза (Lip)", "Ед/л"], ["Альбумин/глобулин (A/G Ratio)", ""], ["Соотношение Ca/P", ""], ["Соотношение Na/K", ""], ["Соотношение Мочевина/Креатинин", ""], ["Кислотность (рН венозной крови)", "рН"], ["Аммиак", "мкмоль/л"], ["Желчные кислоты 1 проба", "мкмоль/л"], ["Желчные кислоты 2 проба", "мкмоль/л"], ["С-реактивный белок", "мг/л"], ["Сывороточный амилоид А кошек", "мкг/мл"], ["Специфическая панкреатическая липаза собак", "нг/мл"], ["Специфическая панкреатическая липаза кошек", "нг/мл"], ["Тропонин 1", "нг/мл"],
+]);
+const coagulation = indicators("coagulation", [["АЧТВ", "сек"], ["Протромбиновое время", "сек"], ["Тромбиновое время", "сек"], ["Фибриноген", "г/л"]]);
+const urine = indicators("urine", [["Цвет", "визуально"], ["Прозрачность мочи", "визуально"], ["Относительная плотность по рефрактометру (ОП)", "г/см³"], ["рН", "ед. рН"], ["Креатинин мочи", "ммоль/л"], ["Белок мочи", "г/л"], ["Белок мочи", "мг/дл"], ["Белок мочи", "ммоль/л"], ["Соотношение Белок/Креатинин", ""], ["Глюкоза мочи", "ммоль/л"], ["Уробилиноген", "качественная реакция"], ["Билирубин", "качественная реакция"], ["Билирубин", "мкмоль/л"], ["Кетоны", "ммоль/л"], ["Кровь", "качественная реакция"], ["Гемоглобин", "качественная реакция"], ["Эритроциты", "в п/зр (HPF)"], ["Лейкоциты в моче", "в п/зр (HPF)"], ["Неорганизованный осадок", "в п/зр (LPF)"], ["Эпителий плоский", "в п/зр (HPF)"], ["Эпителий переходный", "в п/зр (HPF)"], ["Эпителий почечный", "в п/зр (HPF)"], ["Цилиндры гиалиновые", "в п/зр (LPF)"], ["Цилиндры патологические", "в п/зр (LPF)"], ["Неорганический осадок", "в п/зр (LPF)"], ["Слизь", "в п/зр (LPF)"], ["Бактерии в моче", "в п/зр (HPF)"]]);
+const hormones = indicators("hormones", [["Т4 общий (тироксин, общий)", "нмоль/л"], ["ТТГ", ""], ["Прогестерон", ""], ["Инсулин", ""], ["Кортизол", ""], ["Эстрадиол", ""]]);
+const narrative = ["Микроскопия мазка-отпечатка на эктопаразитов", "Микроскопия глубокого соскоба", "Микроскопия дерматофитов", "Микроскопия мазка крови", "Микроскопия кала", "Микроскопия мазка из НСП", "Микроскопия мочи", "Цитология мазка-отпечатка", "Цитология выпота", "Цитология мочи", "Цитология пунктата", "Цитология вагинального мазка", "Цитология новообразования", "Цитология ликвора", "Цитология синовиальной жидкости", "Цитология костного мозга", "Цитология окраски по Граму", "Цитология окраски по Циль-Нельсону", "Гистология мягкой ткани", "Гистология кости"];
+export const LABORATORY_STUDY_CATALOG: readonly LaboratoryStudyTypeCatalogItem[] = [
+  { id: "lab.study.cbc", name: "Общеклинический анализ крови", mode: "panel", indicators: cbc },
+  { id: "lab.study.biochemistry", name: "Биохимический анализ крови", mode: "panel", indicators: biochemistry },
+  { id: "lab.study.coagulation", name: "Коагулограмма крови", mode: "panel", indicators: coagulation },
+  { id: "lab.study.urine", name: "Общеклинический анализ мочи", mode: "panel", indicators: urine },
+  { id: "lab.study.hormones", name: "Исследования крови на гормоны", mode: "panel", indicators: hormones },
+  ...narrative.map((name, index) => ({ id: `lab.study.narrative.${String(index + 1).padStart(3, "0")}`, name, mode: "narrative" as const, indicators: [] })),
+  { id: "lab.study.infection", name: "Исследование на инфекцию", mode: "infection", indicators: [] },
+];
+export const LABORATORY_STUDY_OPTIONS = LABORATORY_STUDY_CATALOG.map(({ id, name }) => ({ id, label: name }));
+const types = new Map(LABORATORY_STUDY_CATALOG.map((item) => [item.id, item]));
+const indicatorsById = new Map(LABORATORY_STUDY_CATALOG.flatMap((study) => study.indicators.map((item) => [item.id, item] as const)));
+export const laboratoryStudyTypeById = (id: string) => types.get(id);
+export const laboratoryIndicatorById = (id: string) => indicatorsById.get(id);
+
+export function normalizeLaboratoryTestsValue(value: unknown, today = new Date().toISOString().slice(0, 10)): LaboratoryTestsSectionValue {
+  if (!value || typeof value !== "object" || !Array.isArray((value as { studies?: unknown }).studies) || !(value as { studies: unknown[] }).studies.length) throw new Error("Добавьте хотя бы одно лабораторное исследование.");
+  const seen = new Set<string>();
+  const studies = (value as { studies: unknown[] }).studies.map((raw) => {
+    if (!raw || typeof raw !== "object") throw new Error("Некорректное лабораторное исследование.");
+    const input = raw as Record<string, unknown>; const id = String(input.id ?? ""); const date = String(input.date ?? ""); const type = types.get(String(input.typeId ?? ""));
+    if (!/^[0-9a-f]{8}-[0-9a-f-]{27}$/i.test(id) || seen.has(id)) throw new Error("Некорректный идентификатор исследования."); seen.add(id);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date) || date > today) throw new Error("Укажите корректную дату исследования.");
+    if (!type) throw new Error("Выберите исследование из справочника.");
+    const laboratory = String(input.laboratory ?? "").trim(); if (!laboratory) throw new Error("Укажите лабораторию.");
+    const base = { id, date, typeId: type.id, typeName: type.name, laboratory, ...optional(input, "technician", "equipment", "comment") };
+    if (type.mode === "panel") {
+      if (!Array.isArray(input.results) || !input.results.length) throw new Error("Выберите и заполните хотя бы один показатель.");
+      const resultIds = new Set<string>(); const results = input.results.map((rawResult) => { const result = rawResult as Record<string, unknown>; const item = indicatorsById.get(String(result?.indicatorId ?? "")); const text = String(result?.result ?? "").trim(); if (!item || !type.indicators.some((candidate) => candidate.id === item.id) || resultIds.has(item.id) || !text) throw new Error("Некорректный результат показателя."); resultIds.add(item.id); return { indicatorId: item.id, indicatorName: item.name, unit: item.unit, result: text, ...optional(result, "reference") }; });
+      return { ...base, mode: "panel" as const, results };
+    }
+    if (type.mode === "narrative") { const result = String(input.result ?? "").trim(); if (!result) throw new Error("Укажите результат исследования."); return { ...base, mode: "narrative" as const, result }; }
+    const infection = String(input.infection ?? "").trim(); const method = String(input.method ?? ""); const result = String(input.result ?? ""); if (!infection || !["ПЦР", "ИФА", "РМА", "ELISA", "ИХА"].includes(method) || !["positive", "negative"].includes(result)) throw new Error("Заполните исследование на инфекцию.");
+    return { ...base, mode: "infection" as const, infection, method, result } as LaboratoryInfectionStudyValue;
+  });
+  return { studies };
+}
+function optional(input: Record<string, unknown>, ...keys: string[]): Record<string, string> { return Object.fromEntries(keys.flatMap((key) => { const value = String(input[key] ?? "").trim(); return value ? [[key, value]] : []; })); }

--- a/src/components/AppCatalogCombobox.vue
+++ b/src/components/AppCatalogCombobox.vue
@@ -40,6 +40,7 @@ const props = withDefaults(defineProps<{
   twoLevel?: boolean;
   categoryPrompt?: string;
   allCategoriesLabel?: string;
+  allowCustom?: boolean;
 }>(), {
   options: () => [],
   groups: () => [],
@@ -54,6 +55,7 @@ const props = withDefaults(defineProps<{
   twoLevel: false,
   categoryPrompt: "Выберите категорию",
   allCategoriesLabel: "Все категории",
+  allowCustom: true,
 });
 const selectedIds = defineModel<string[]>("selectedIds", { required: true });
 const customText = defineModel<string>("customText", { required: true });
@@ -145,7 +147,7 @@ const toggleTitle = computed(() => {
 });
 const canAddCustomValue = computed(() => {
   const value = normalizeSearch(inputValue.value);
-  return props.multiple && Boolean(value)
+  return props.allowCustom && props.multiple && Boolean(value)
     && !customTexts.value.some((text) => normalizeSearch(text) === value);
 });
 
@@ -340,7 +342,7 @@ onBeforeUnmount(() => {
         @keydown.esc.stop.prevent="handleEscape"
       />
       <button
-        v-if="multiple"
+        v-if="allowCustom && multiple"
         type="button"
         class="outline-action inline owner-profile-action app-catalog-add"
         :disabled="!canAddCustomValue"

--- a/src/components/EncounterEditorForm.vue
+++ b/src/components/EncounterEditorForm.vue
@@ -7,6 +7,7 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue"
 import AppIcon from "./AppIcon.vue";
 import DiagnosisEditor from "./DiagnosisEditor.vue";
 import TherapeuticAppointmentForm from "./TherapeuticAppointmentForm.vue";
+import LaboratoryTestsEditor from "./LaboratoryTestsEditor.vue";
 import WhatHappenedTree from "./WhatHappenedTree.vue";
 import {
   ENCOUNTER_SECTION_LABELS,
@@ -41,6 +42,7 @@ import type {
   TherapeuticAppointmentDraftErrors,
 } from "../therapeuticAppointment";
 import type { MedicalEncounterSectionKind } from "../repositories/types";
+import { normalizeLaboratoryTestsValue, type LaboratoryTestsSectionValue } from "@klinok/contracts";
 
 const props = defineProps<{
   busy: boolean;
@@ -65,11 +67,13 @@ const generalData = defineModel<GeneralDataDraft>("generalData", { required: tru
 const vaccination = defineModel<VaccinationDraft>("vaccination", { required: true });
 const therapeuticAppointment = defineModel<TherapeuticAppointmentDraft>("therapeuticAppointment", { required: true });
 const diagnosis = defineModel<DiagnosisDraft>("diagnosis", { required: true });
+const laboratoryTests = defineModel<LaboratoryTestsSectionValue>("laboratoryTests", { required: true });
 const form = ref<HTMLFormElement | null>(null);
 const generalDataErrors = ref<GeneralDataDraftErrors>({});
 const vaccinationErrors = ref<VaccinationDraftErrors>({});
 const therapeuticErrors = ref<TherapeuticAppointmentDraftErrors>({});
 const diagnosisErrors = ref<DiagnosisDraftErrors>({});
+const laboratoryError = ref("");
 const revaccinationInterval = ref<RevaccinationInterval | "">("");
 const revaccinationChooserOpen = ref(false);
 const revaccinationMenuRoot = ref<HTMLElement | null>(null);
@@ -133,6 +137,13 @@ function selectOptional(event: Event) {
       diagnosisErrors.value = {};
       const nextTexts = { ...texts.value };
       delete nextTexts.diagnosis;
+      texts.value = nextTexts;
+    }
+    if (kind === "laboratory-tests") {
+      laboratoryTests.value = { studies: [] };
+      laboratoryError.value = "";
+      const nextTexts = { ...texts.value };
+      delete nextTexts["laboratory-tests"];
       texts.value = nextTexts;
     }
   }
@@ -216,6 +227,10 @@ function submit() {
     const parsed = parseDiagnosisDraft(diagnosis.value);
     diagnosisErrors.value = parsed.errors;
     if (!parsed.value) return;
+  }
+  if (optionalKinds.value.includes("laboratory-tests") && texts.value["laboratory-tests"] === undefined) {
+    try { normalizeLaboratoryTestsValue(laboratoryTests.value); laboratoryError.value = ""; }
+    catch (reason) { laboratoryError.value = reason instanceof Error ? reason.message : "Проверьте лабораторные исследования."; return; }
   }
   if (form.value?.reportValidity() === false) return;
   emit("save");
@@ -377,6 +392,9 @@ function submit() {
           :errors="therapeuticErrors"
           @update:model-value="updateTherapeuticAppointment"
         />
+      </template>
+      <template v-else-if="kind === 'laboratory-tests' && texts[kind] === undefined">
+        <LaboratoryTestsEditor v-model="laboratoryTests" :encounter-date="date" :errors="laboratoryError" />
       </template>
       <template v-else>
         <p class="temporary-note">{{ kind === 'general-data' ? 'Сохранён старый шаблон free-text-v0.' : 'Временный универсальный шаблон free-text-v0.' }}</p>

--- a/src/components/LaboratoryComparison.vue
+++ b/src/components/LaboratoryComparison.vue
@@ -4,13 +4,18 @@
 // This file is a part of Klinok application
 
 import { computed, ref, watch } from "vue";
-import type { LaboratoryTestsSectionValue, MedicalRecordDraft } from "@klinok/contracts";
+import type { MedicalRecordDraft } from "@klinok/contracts";
+import { isLaboratoryTestsValue } from "../medicalEncounter";
 import AppCatalogCombobox from "./AppCatalogCombobox.vue";
 import AppPaginator from "./AppPaginator.vue";
 
 const props = defineProps<{ records: readonly MedicalRecordDraft[]; confirmedIds: ReadonlySet<string> }>();
 const selectedIds = ref<string[]>([]); const customText = ref(""); const page = ref(1); const pageSize = ref<10 | 20 | 50>(10);
-const occurrences = computed(() => props.records.flatMap((record) => { const value = record.sections["laboratory-tests"]?.value as LaboratoryTestsSectionValue | undefined; return value?.studies.flatMap((study) => study.mode === "panel" ? [{ record, study }] : []) ?? []; }).sort((a, b) => a.study.date.localeCompare(b.study.date) || a.study.id.localeCompare(b.study.id)));
+const occurrences = computed(() => props.records.flatMap((record) => {
+  const section = record.sections["laboratory-tests"];
+  if (section?.templateVersion !== "laboratory-tests-v1" || !isLaboratoryTestsValue(section.value)) return [];
+  return section.value.studies.flatMap((study) => study.mode === "panel" ? [{ record, study }] : []);
+}).sort((a, b) => a.study.date.localeCompare(b.study.date) || a.study.id.localeCompare(b.study.id)));
 const indicatorMap = computed(() => new Map(occurrences.value.flatMap(({ study }) => study.mode === "panel" ? study.results.map((result) => [result.indicatorId, { id: result.indicatorId, label: result.unit ? `${result.indicatorName}, ${result.unit}` : result.indicatorName }] as const) : [])));
 const options = computed(() => [...indicatorMap.value.values()]);
 const rows = computed(() => occurrences.value.filter(({ study }) => study.mode === "panel" && study.results.some((result) => selectedIds.value.includes(result.indicatorId))));

--- a/src/components/LaboratoryComparison.vue
+++ b/src/components/LaboratoryComparison.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Klinok application
+
+import { computed, ref, watch } from "vue";
+import type { LaboratoryTestsSectionValue, MedicalRecordDraft } from "@klinok/contracts";
+import AppCatalogCombobox from "./AppCatalogCombobox.vue";
+import AppPaginator from "./AppPaginator.vue";
+
+const props = defineProps<{ records: readonly MedicalRecordDraft[]; confirmedIds: ReadonlySet<string> }>();
+const selectedIds = ref<string[]>([]); const customText = ref(""); const page = ref(1); const pageSize = ref<10 | 20 | 50>(10);
+const occurrences = computed(() => props.records.flatMap((record) => { const value = record.sections["laboratory-tests"]?.value as LaboratoryTestsSectionValue | undefined; return value?.studies.flatMap((study) => study.mode === "panel" ? [{ record, study }] : []) ?? []; }).sort((a, b) => a.study.date.localeCompare(b.study.date) || a.study.id.localeCompare(b.study.id)));
+const indicatorMap = computed(() => new Map(occurrences.value.flatMap(({ study }) => study.mode === "panel" ? study.results.map((result) => [result.indicatorId, { id: result.indicatorId, label: result.unit ? `${result.indicatorName}, ${result.unit}` : result.indicatorName }] as const) : [])));
+const options = computed(() => [...indicatorMap.value.values()]);
+const rows = computed(() => occurrences.value.filter(({ study }) => study.mode === "panel" && study.results.some((result) => selectedIds.value.includes(result.indicatorId))));
+const paged = computed(() => rows.value.slice((page.value - 1) * pageSize.value, page.value * pageSize.value));
+watch([selectedIds, pageSize], () => { page.value = 1; }, { deep: true });
+function result(study: (typeof occurrences.value)[number]["study"], id: string) { return study.mode === "panel" ? study.results.find((item) => item.indicatorId === id) : undefined; }
+function date(value: string) { const [year, month, day] = value.split("-"); return `${day}.${month}.${year}`; }
+</script>
+<template>
+  <section v-if="options.length" class="laboratory-comparison">
+    <h3>Сравнение лабораторных показателей</h3>
+    <AppCatalogCombobox v-model:selected-ids="selectedIds" v-model:custom-text="customText" multiple :allow-custom="false" label="Показатели для сравнения" :options="options" placeholder="Выберите показатели" />
+    <div v-if="selectedIds.length" class="laboratory-results-scroll"><table class="laboratory-results"><thead><tr><th>Дата</th><th>Исследование</th><th>Лаборатория</th><th>Статус</th><th v-for="id in selectedIds" :key="id">{{ indicatorMap.get(id)?.label }}</th></tr></thead><tbody><tr v-for="row in paged" :key="`${row.record.recordId}:${row.study.id}`"><td>{{ date(row.study.date) }}</td><td>{{ row.study.typeName }}</td><td>{{ row.study.laboratory }}</td><td>{{ confirmedIds.has(row.record.recordId) ? 'Подтверждено' : 'Ожидает подтверждения' }}</td><td v-for="id in selectedIds" :key="id"><template v-if="result(row.study, id)">{{ result(row.study, id)?.result }}<small v-if="result(row.study, id)?.reference" class="muted-label">Реф.: {{ result(row.study, id)?.reference }}</small></template><span v-else>—</span></td></tr></tbody></table></div>
+    <AppPaginator v-if="selectedIds.length && rows.length" v-model:page="page" v-model:page-size="pageSize" :total-items="rows.length" :page-sizes="[10, 20, 50]" page-size-label="Исследований на странице" aria-label="Навигация по сравнению лабораторных показателей" />
+  </section>
+</template>

--- a/src/components/LaboratoryTestsEditor.vue
+++ b/src/components/LaboratoryTestsEditor.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Klinok application
+
+import { computed, ref } from "vue";
+import { LABORATORY_STUDY_OPTIONS, laboratoryStudyTypeById, type LaboratoryPanelStudyValue, type LaboratoryStudyValue, type LaboratoryTestsSectionValue } from "@klinok/contracts";
+import AppCatalogCombobox from "./AppCatalogCombobox.vue";
+import AppIcon from "./AppIcon.vue";
+import ConfirmationDialog from "./ConfirmationDialog.vue";
+
+const props = defineProps<{ encounterDate: string; errors?: string }>();
+const model = defineModel<LaboratoryTestsSectionValue>({ required: true });
+const pending = ref<(() => void) | null>(null);
+const confirmOpen = computed({ get: () => Boolean(pending.value), set: (value) => { if (!value) pending.value = null; } });
+const uuid = () => globalThis.crypto.randomUUID();
+function addStudy() { model.value = { studies: [...model.value.studies, { id: uuid(), date: props.encounterDate, typeId: "", typeName: "", mode: "panel", laboratory: "", results: [] } as LaboratoryStudyValue] }; }
+function populated(study: LaboratoryStudyValue) { return study.laboratory || study.technician || study.equipment || study.comment || (study.mode === "panel" ? study.results.length : study.mode === "narrative" ? study.result : study.infection); }
+function destructive(action: () => void, hasData = true) { if (!hasData) action(); else pending.value = action; }
+function removeStudy(index: number) { const study = model.value.studies[index]!; destructive(() => { model.value = { studies: model.value.studies.filter((_, candidate) => candidate !== index) }; }, Boolean(populated(study))); }
+function changeType(study: LaboratoryStudyValue, ids: string[]) {
+  const next = laboratoryStudyTypeById(ids[0] ?? ""); if (!next || next.id === study.typeId) return;
+  destructive(() => { const base = { id: study.id, date: study.date, typeId: next.id, typeName: next.name, laboratory: study.laboratory, ...(study.technician ? { technician: study.technician } : {}), ...(study.equipment ? { equipment: study.equipment } : {}), ...(study.comment ? { comment: study.comment } : {}) }; const replacement = next.mode === "panel" ? { ...base, mode: "panel" as const, results: [] } : next.mode === "narrative" ? { ...base, mode: "narrative" as const, result: "" } : { ...base, mode: "infection" as const, infection: "", method: "ПЦР" as const, result: "negative" as const }; Object.assign(study, replacement); for (const key of ["results", "result", "infection", "method"] as const) if (!(key in replacement)) delete (study as unknown as Record<string, unknown>)[key]; }, Boolean(study.typeId && populated(study)));
+}
+function indicatorOptions(study: LaboratoryStudyValue) { return laboratoryStudyTypeById(study.typeId)?.indicators.map(({ id, name, unit }) => ({ id, label: unit ? `${name} — ${unit}` : name })) ?? []; }
+function selectedIndicatorIds(study: LaboratoryStudyValue) { return study.mode === "panel" ? study.results.map((result) => result.indicatorId) : []; }
+function changeIndicators(study: LaboratoryStudyValue, ids: string[]) { if (study.mode !== "panel") return; const type = laboratoryStudyTypeById(study.typeId); if (!type) return; const removed = study.results.filter((result) => !ids.includes(result.indicatorId)); const apply = () => { (study as { results: LaboratoryPanelStudyValue["results"] }).results = ids.map((id) => study.results.find((result) => result.indicatorId === id) ?? (() => { const item = type.indicators.find((candidate) => candidate.id === id)!; return { indicatorId: item.id, indicatorName: item.name, unit: item.unit, result: "" }; })()); }; destructive(apply, removed.some((item) => item.result || item.reference)); }
+function confirm() { const action = pending.value; pending.value = null; action?.(); }
+</script>
+
+<template>
+  <p v-if="errors" class="field-error" role="alert">{{ errors }}</p>
+  <div class="laboratory-study-list">
+    <section v-for="(study, index) in model.studies" :key="study.id" class="laboratory-study-card">
+      <div class="doctor-heading"><h4>Исследование {{ index + 1 }}</h4><button type="button" class="outline-action inline danger-outline owner-profile-action" title="Удалить исследование" aria-label="Удалить исследование" @click="removeStudy(index)"><AppIcon name="trash" /></button></div>
+      <div class="laboratory-metadata">
+        <label><span>Дата исследования</span><input v-model="study.date" type="date" :max="new Date().toISOString().slice(0, 10)" required /></label>
+        <div><span class="field-label">Название исследования</span><AppCatalogCombobox label="Название исследования" :options="LABORATORY_STUDY_OPTIONS" :selected-ids="study.typeId ? [study.typeId] : []" custom-text="" :allow-custom="false" @update:selected-ids="changeType(study, $event)" /></div>
+        <label><span>Лаборатория</span><input v-model="study.laboratory" required /></label>
+        <label><span>ФИО лаборанта</span><input v-model="study.technician" /></label>
+        <label><span>Оборудование</span><input v-model="study.equipment" /></label>
+      </div>
+      <template v-if="study.mode === 'panel' && study.typeId">
+        <div><span class="field-label">Показатели</span><AppCatalogCombobox label="Показатели" multiple :options="indicatorOptions(study)" :selected-ids="selectedIndicatorIds(study)" custom-text="" :allow-custom="false" @update:selected-ids="changeIndicators(study, $event)" /></div>
+        <div v-if="study.results.length" class="laboratory-results-scroll"><table class="laboratory-results"><thead><tr><th>Показатель</th><th>Результат</th><th>Ед. измерения</th><th>Референсные значения</th></tr></thead><tbody><tr v-for="result in study.results" :key="result.indicatorId"><td>{{ result.indicatorName }}</td><td><input v-model="result.result" required /></td><td>{{ result.unit || '—' }}</td><td><input v-model="result.reference" /></td></tr></tbody></table></div>
+      </template>
+      <label v-else-if="study.mode === 'narrative'"><span>Результат</span><textarea v-model="study.result" rows="4" required /></label>
+      <div v-else-if="study.mode === 'infection'" class="laboratory-infection"><label><span>Инфекция</span><input v-model="study.infection" required /></label><label><span>Метод</span><select v-model="study.method"><option v-for="method in ['ПЦР','ИФА','РМА','ELISA','ИХА']" :key="method">{{ method }}</option></select></label><fieldset class="medical-card-option-panel"><legend>Результат</legend><div class="medical-card-options"><label><input v-model="study.result" type="radio" value="positive" /> Положительно</label><label><input v-model="study.result" type="radio" value="negative" /> Отрицательно</label></div></fieldset></div>
+      <label><span>Комментарий</span><textarea v-model="study.comment" class="medical-card-comment" rows="2" /></label>
+    </section>
+  </div>
+  <button type="button" class="outline-action inline" @click="addStudy"><AppIcon name="plus" /> Добавить исследование</button>
+  <ConfirmationDialog v-model="confirmOpen" title="Удалить заполненные данные?" description="После подтверждения будут удалены только данные выбранного исследования или показателя." confirm-label="Удалить" @confirm="confirm" />
+</template>

--- a/src/components/MedicalRecordEntry.vue
+++ b/src/components/MedicalRecordEntry.vue
@@ -21,6 +21,7 @@ import {
   isGeneralDataValue,
   isOutcomeValue,
   isVaccinationValue,
+  isLaboratoryTestsValue,
   isWhatHappenedValue,
   outcomeComment,
   outcomeLabel,
@@ -214,6 +215,18 @@ function formatLocalDateTime(value: string) {
           v-else-if="item.kind === 'therapeutic-appointment' && isTherapeuticAppointmentValue(item.section.value)"
           :value="item.section.value"
         />
+        <div v-else-if="isLaboratoryTestsValue(item.section.value)" class="laboratory-history">
+          <section v-for="study in item.section.value.studies" :key="study.id" class="laboratory-history-study">
+            <h4>{{ formatDate(study.date) }} · {{ study.typeName }}</h4>
+            <p><span class="muted-label">Лаборатория</span> {{ study.laboratory }}</p>
+            <p v-if="study.technician"><span class="muted-label">Лаборант</span> {{ study.technician }}</p>
+            <p v-if="study.equipment"><span class="muted-label">Оборудование</span> {{ study.equipment }}</p>
+            <div v-if="study.mode === 'panel'" class="laboratory-results-scroll"><table class="laboratory-results"><thead><tr><th>Показатель</th><th>Результат</th><th>Ед. измерения</th><th>Референсные значения</th></tr></thead><tbody><tr v-for="result in study.results" :key="result.indicatorId"><td>{{ result.indicatorName }}</td><td>{{ result.result }}</td><td>{{ result.unit || '—' }}</td><td>{{ result.reference || '—' }}</td></tr></tbody></table></div>
+            <p v-else-if="study.mode === 'narrative'">{{ study.result }}</p>
+            <dl v-else><div><dt>Инфекция</dt><dd>{{ study.infection }}</dd></div><div><dt>Метод</dt><dd>{{ study.method }}</dd></div><div><dt>Результат</dt><dd>{{ study.result === 'positive' ? 'Положительно' : 'Отрицательно' }}</dd></div></dl>
+            <p v-if="study.comment" class="encounter-history-comment">{{ study.comment }}</p>
+          </section>
+        </div>
         <dl v-else-if="isGeneralDataValue(item.section.value)" class="general-data-values">
           <div v-for="measurement in generalDataMeasurements(item.section.value)" :key="measurement.key">
             <dt>{{ measurement.label }}</dt>

--- a/src/medicalEncounter.ts
+++ b/src/medicalEncounter.ts
@@ -12,6 +12,7 @@ import type {
   OutcomeSectionValue,
   VaccinationSectionValue,
   WhatHappenedSectionValue,
+  LaboratoryTestsSectionValue,
 } from "./repositories/types";
 import {
   DIAGNOSIS_CATALOG_OPTIONS,
@@ -723,7 +724,12 @@ export function sectionSearchText(value: unknown): string {
   if (isTherapeuticAppointmentValue(value)) return therapeuticAppointmentSearchText(value);
   if (isGeneralDataValue(value)) return generalDataMeasurements(value).map((item) => `${item.label} ${item.value}`).join(" ");
   if (isVaccinationValue(value)) return vaccinationDetails(value).map((item) => `${item.label} ${item.value}`).join(" ");
+  if (isLaboratoryTestsValue(value)) return value.studies.flatMap((study) => [study.date, study.typeName, study.laboratory, study.technician, study.equipment, study.comment, study.mode === "panel" ? study.results.flatMap((result) => [result.indicatorName, result.result, result.unit, result.reference]) : study.mode === "narrative" ? study.result : [study.infection, study.method, study.result]]).flat(Infinity).filter(Boolean).join(" ");
   return "";
+}
+
+export function isLaboratoryTestsValue(value: unknown): value is LaboratoryTestsSectionValue {
+  return Boolean(value && typeof value === "object" && Array.isArray((value as LaboratoryTestsSectionValue).studies));
 }
 
 export function whatHappenedSelectedIds(value: unknown): readonly string[] {

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -57,7 +57,8 @@ function optimisticRecord(command: ClientCommand, snapshot: AppSnapshotDto): Med
   const profile = snapshot.control.profile;
   const authorDisplayName = [profile?.firstName, profile?.patronymic, profile?.lastName].filter(Boolean).join(" ") || profile?.accountId || "";
   const previous = snapshot.medical.records.find((record) => record.recordId === command.entityId);
-  const sections = Object.fromEntries(Object.entries(input.sections).map(([kind, value]) => [kind, {
+  const sections = Object.fromEntries(Object.entries(input.sections).flatMap(([kind, value]) =>
+    kind === "laboratory-tests" && value && typeof value === "object" && "text" in value ? [] : [[kind, {
     kind,
     templateVersion: kind === "what-happened" ? "what-happened-v1" : kind === "outcome" ? "outcome-v1"
       : kind === "diagnosis" ? "diagnosis-v2"
@@ -66,7 +67,7 @@ function optimisticRecord(command: ClientCommand, snapshot: AppSnapshotDto): Med
           : kind === "therapeutic-appointment" && !(value && typeof value === "object" && "text" in value) ? "therapeutic-appointment-v1"
             : kind === "laboratory-tests" && !(value && typeof value === "object" && "text" in value) ? "laboratory-tests-v1" : "free-text-v0",
     value, authorAccountId: profile?.accountId ?? "", authorDisplayName, updatedAt: now,
-  }])) as MedicalRecordDraft["sections"];
+  }]])) as MedicalRecordDraft["sections"];
   return {
     recordId: command.entityId, petId: input.petId, revision: previous ? previous.revision + 1 : 1,
     authorAccountId: previous?.authorAccountId ?? profile?.accountId ?? "", authorDisplayName: previous?.authorDisplayName ?? authorDisplayName,

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -63,7 +63,8 @@ function optimisticRecord(command: ClientCommand, snapshot: AppSnapshotDto): Med
       : kind === "diagnosis" ? "diagnosis-v2"
       : kind === "general-data" && !(value && typeof value === "object" && "text" in value) ? "general-data-v1"
         : kind === "vaccination" && !(value && typeof value === "object" && "text" in value) ? "vaccination-v1"
-          : kind === "therapeutic-appointment" && !(value && typeof value === "object" && "text" in value) ? "therapeutic-appointment-v1" : "free-text-v0",
+          : kind === "therapeutic-appointment" && !(value && typeof value === "object" && "text" in value) ? "therapeutic-appointment-v1"
+            : kind === "laboratory-tests" && !(value && typeof value === "object" && "text" in value) ? "laboratory-tests-v1" : "free-text-v0",
     value, authorAccountId: profile?.accountId ?? "", authorDisplayName, updatedAt: now,
   }])) as MedicalRecordDraft["sections"];
   return {

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -14,6 +14,7 @@ export type {
   DiagnosisTaxonomyId,
   FreeTextSectionValue,
   GeneralDataSectionValue,
+  LaboratoryTestsSectionValue,
   MedicalEncounterInput,
   MedicalEncounterSection,
   MedicalEncounterSectionInputValue,
@@ -36,4 +37,9 @@ export {
   DIAGNOSIS_CATALOG_OPTIONS,
   MEDICAL_ENCOUNTER_SECTION_KINDS,
   isDiagnosisTaxonomyId,
+  LABORATORY_STUDY_CATALOG,
+  LABORATORY_STUDY_OPTIONS,
+  laboratoryIndicatorById,
+  laboratoryStudyTypeById,
+  normalizeLaboratoryTestsValue,
 } from "@klinok/contracts";

--- a/src/screens/DoctorScreen.vue
+++ b/src/screens/DoctorScreen.vue
@@ -7,6 +7,8 @@ import { computed, reactive, ref, watch } from "vue";
 import { RouterLink, useRoute, useRouter } from "vue-router";
 import {
   normalizeRussianSearchText,
+  normalizeLaboratoryTestsValue,
+  type LaboratoryTestsSectionValue,
   type DirectoryPetDto,
   type DirectoryProfileDto,
   type DoctorPetAccessDto,
@@ -18,6 +20,7 @@ import AppPaginator from "../components/AppPaginator.vue";
 import ConfirmationDialog from "../components/ConfirmationDialog.vue";
 import EncounterEditorForm from "../components/EncounterEditorForm.vue";
 import MedicalRecordEntry from "../components/MedicalRecordEntry.vue";
+import LaboratoryComparison from "../components/LaboratoryComparison.vue";
 import ModalDialog from "../components/ModalDialog.vue";
 import PetAccessManager from "../components/PetAccessManager.vue";
 import PetProfileView from "../components/PetProfileView.vue";
@@ -142,6 +145,7 @@ const encounter = reactive({
   vaccination: emptyVaccinationDraft(),
   therapeuticAppointment: emptyTherapeuticAppointmentDraft(),
   diagnosis: emptyDiagnosisDraft(),
+  laboratoryTests: { studies: [] } as LaboratoryTestsSectionValue,
 });
 
 const profileName = computed(() => [appState.control.profile?.firstName, appState.control.profile?.patronymic, appState.control.profile?.lastName].filter(Boolean).join(" "));
@@ -364,6 +368,7 @@ function removeOptional(kind: MedicalEncounterSectionKind) {
   if (kind === "vaccination") encounter.vaccination = emptyVaccinationDraft(selectedPet.value?.latestConfirmedVaccination);
   if (kind === "therapeutic-appointment") encounter.therapeuticAppointment = emptyTherapeuticAppointmentDraft();
   if (kind === "diagnosis") encounter.diagnosis = emptyDiagnosisDraft();
+  if (kind === "laboratory-tests") encounter.laboratoryTests = { studies: [] };
 }
 
 function requestRemoveOptional(kind: MedicalEncounterSectionKind) {
@@ -392,6 +397,7 @@ function resetEncounter() {
   encounter.vaccination = emptyVaccinationDraft();
   encounter.therapeuticAppointment = emptyTherapeuticAppointmentDraft();
   encounter.diagnosis = emptyDiagnosisDraft();
+  encounter.laboratoryTests = { studies: [] };
 }
 
 async function saveEncounter() {
@@ -403,6 +409,8 @@ async function saveEncounter() {
         const parsed = parseDiagnosisDraft(encounter.diagnosis);
         if (!parsed.value) throw new Error("Проверьте данные в разделе «Диагноз».");
         optionalSections[kind] = parsed.value;
+      } else if (kind === "laboratory-tests" && encounter.texts[kind] === undefined) {
+        optionalSections[kind] = normalizeLaboratoryTestsValue(encounter.laboratoryTests);
       } else if (kind === "general-data" && encounter.texts[kind] === undefined) {
         const parsed = parseGeneralDataDraft(encounter.generalData);
         if (!parsed.value) throw new Error("Проверьте показатели в разделе «Общие данные/Габитус».");
@@ -457,6 +465,9 @@ function editRecord(record: (typeof appState.medical.records)[number]) {
     : emptyTherapeuticAppointmentDraft();
   const diagnosisValue = record.sections.diagnosis?.value;
   encounter.diagnosis = isDiagnosisValue(diagnosisValue) ? diagnosisDraft(diagnosisValue) : emptyDiagnosisDraft();
+  const laboratoryValue = record.sections["laboratory-tests"]?.value;
+  encounter.laboratoryTests = laboratoryValue && typeof laboratoryValue === "object" && "studies" in laboratoryValue
+    ? structuredClone(laboratoryValue as LaboratoryTestsSectionValue) : { studies: [] };
   encounter.texts = Object.fromEntries(encounter.optionalKinds.flatMap((kind) => {
     const value = record.sections[kind]?.value;
     return kind !== "diagnosis" && isFreeTextValue(value) ? [[kind, value.text]] : [];
@@ -491,6 +502,9 @@ function recoverRecordDraft(command: {
     : emptyTherapeuticAppointmentDraft();
   const diagnosisValue = input.sections.diagnosis;
   encounter.diagnosis = isDiagnosisValue(diagnosisValue) ? diagnosisDraft(diagnosisValue) : emptyDiagnosisDraft();
+  const laboratoryValue = input.sections["laboratory-tests"];
+  encounter.laboratoryTests = laboratoryValue && typeof laboratoryValue === "object" && "studies" in laboratoryValue
+    ? structuredClone(laboratoryValue as LaboratoryTestsSectionValue) : { studies: [] };
   encounter.texts = Object.fromEntries(encounter.optionalKinds.flatMap((kind) => {
     const value = input.sections[kind];
     return kind !== "diagnosis" && isFreeTextValue(value) ? [[kind, value.text]] : [];
@@ -853,6 +867,7 @@ watch(delegationPageCount, (pageCount) => {
           v-model:vaccination="encounter.vaccination"
           v-model:therapeutic-appointment="encounter.therapeuticAppointment"
           v-model:diagnosis="encounter.diagnosis"
+          v-model:laboratory-tests="encounter.laboratoryTests"
           :busy="busy"
           :editing="false"
           :latest-confirmed-vaccination="selectedPet.latestConfirmedVaccination"
@@ -865,6 +880,7 @@ watch(delegationPageCount, (pageCount) => {
 
       <article class="panel doctor-medical-record">
         <h2>Медицинская карта</h2>
+        <LaboratoryComparison :records="petRecords" :confirmed-ids="confirmedIds" />
         <div class="doctor-history-filters">
           <input v-model="historyQuery" type="search" placeholder="Содержание или автор" aria-label="Поиск по истории" />
           <label class="doctor-history-date-filter"><span>Дата с</span><input v-model="historyFrom" type="date" /></label>
@@ -898,6 +914,7 @@ watch(delegationPageCount, (pageCount) => {
                 v-model:vaccination="encounter.vaccination"
                 v-model:therapeutic-appointment="encounter.therapeuticAppointment"
                 v-model:diagnosis="encounter.diagnosis"
+                v-model:laboratory-tests="encounter.laboratoryTests"
                 :busy="busy"
                 editing
                 :latest-confirmed-vaccination="selectedPet.latestConfirmedVaccination"

--- a/src/screens/DoctorScreen.vue
+++ b/src/screens/DoctorScreen.vue
@@ -3,7 +3,7 @@
 // All rights reserved.
 // This file is a part of Klinok application
 
-import { computed, reactive, ref, watch } from "vue";
+import { computed, reactive, ref, toRaw, watch } from "vue";
 import { RouterLink, useRoute, useRouter } from "vue-router";
 import {
   normalizeRussianSearchText,
@@ -467,7 +467,7 @@ function editRecord(record: (typeof appState.medical.records)[number]) {
   encounter.diagnosis = isDiagnosisValue(diagnosisValue) ? diagnosisDraft(diagnosisValue) : emptyDiagnosisDraft();
   const laboratoryValue = record.sections["laboratory-tests"]?.value;
   encounter.laboratoryTests = laboratoryValue && typeof laboratoryValue === "object" && "studies" in laboratoryValue
-    ? structuredClone(laboratoryValue as LaboratoryTestsSectionValue) : { studies: [] };
+    ? structuredClone(toRaw(laboratoryValue as LaboratoryTestsSectionValue)) : { studies: [] };
   encounter.texts = Object.fromEntries(encounter.optionalKinds.flatMap((kind) => {
     const value = record.sections[kind]?.value;
     return kind !== "diagnosis" && isFreeTextValue(value) ? [[kind, value.text]] : [];
@@ -504,7 +504,7 @@ function recoverRecordDraft(command: {
   encounter.diagnosis = isDiagnosisValue(diagnosisValue) ? diagnosisDraft(diagnosisValue) : emptyDiagnosisDraft();
   const laboratoryValue = input.sections["laboratory-tests"];
   encounter.laboratoryTests = laboratoryValue && typeof laboratoryValue === "object" && "studies" in laboratoryValue
-    ? structuredClone(laboratoryValue as LaboratoryTestsSectionValue) : { studies: [] };
+    ? structuredClone(toRaw(laboratoryValue as LaboratoryTestsSectionValue)) : { studies: [] };
   encounter.texts = Object.fromEntries(encounter.optionalKinds.flatMap((kind) => {
     const value = input.sections[kind];
     return kind !== "diagnosis" && isFreeTextValue(value) ? [[kind, value.text]] : [];

--- a/src/screens/OwnerScreen.vue
+++ b/src/screens/OwnerScreen.vue
@@ -15,6 +15,7 @@ import AppIcon from "../components/AppIcon.vue";
 import AppPaginator from "../components/AppPaginator.vue";
 import ConfirmationDialog from "../components/ConfirmationDialog.vue";
 import MedicalRecordEntry from "../components/MedicalRecordEntry.vue";
+import LaboratoryComparison from "../components/LaboratoryComparison.vue";
 import ModalDialog from "../components/ModalDialog.vue";
 import PendingCountBadge from "../components/PendingCountBadge.vue";
 import PetAccessManager from "../components/PetAccessManager.vue";
@@ -643,7 +644,6 @@ function confirmMedicalRecord(record: MedicalRecordDraft) {
             </RouterLink>
           </div>
         </div>
-
         <p v-if="formError" class="field-error" role="alert">{{ formError }}</p>
 
         <div class="owner-form-grid">
@@ -816,6 +816,7 @@ function confirmMedicalRecord(record: MedicalRecordDraft) {
           </h2>
           <PendingCountBadge :count="selectedPetPending?.medicalRecords ?? 0" />
         </div>
+        <LaboratoryComparison :records="petRecords" :confirmed-ids="confirmedIds" />
         <div class="medical-record-filters">
           <input v-model="medicalQuery" type="search" placeholder="Содержание или автор" aria-label="Поиск по истории" />
           <label class="medical-record-date-filter"><span>Дата с</span><input v-model="medicalFrom" type="date" /></label>

--- a/src/styles.css
+++ b/src/styles.css
@@ -3017,3 +3017,13 @@ dd {
   .owner-access-table td.is-empty { display: none; }
   .owner-access-table td.doctor-access-empty { display: block; text-align: center; }
 }
+.laboratory-study-list { display: grid; gap: 1rem; }
+.laboratory-study-card { border: 1px solid var(--border-color, #d7dde5); border-radius: .75rem; padding: 1rem; display: grid; gap: .85rem; }
+.laboratory-metadata { display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); gap: .75rem; align-items: start; }
+.laboratory-results-scroll { max-width: 100%; overflow-x: auto; }
+.laboratory-results { width: 100%; min-width: 42rem; border-collapse: collapse; }
+.laboratory-results th, .laboratory-results td { padding: .5rem; border-bottom: 1px solid var(--border-color, #d7dde5); text-align: left; vertical-align: top; }
+.laboratory-results input { min-width: 8rem; }
+.laboratory-infection { display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); gap: .75rem; align-items: start; }
+.laboratory-history, .laboratory-history-study { display: grid; gap: .55rem; }
+.laboratory-history-study + .laboratory-history-study { border-top: 1px solid var(--border-color, #d7dde5); padding-top: 1rem; }

--- a/tests/doctorPages.spec.ts
+++ b/tests/doctorPages.spec.ts
@@ -7,8 +7,11 @@ import { createMemoryHistory, createRouter } from "vue-router";
 import { createPinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { DoctorPetAccessDto, PetAccessRequest } from "@klinok/contracts";
+import AppCatalogCombobox from "../src/components/AppCatalogCombobox.vue";
 import AppIcon from "../src/components/AppIcon.vue";
+import LaboratoryTestsEditor from "../src/components/LaboratoryTestsEditor.vue";
 import DoctorScreen from "../src/screens/DoctorScreen.vue";
+import type { SyncNotification } from "../src/repositories/offlineStore";
 import type { MedicalRecordDraft, MedicalSnapshot, PetProfile } from "../src/repositories/types";
 
 const repositoryMocks = vi.hoisted(() => ({
@@ -32,6 +35,7 @@ vi.mock("../src/appStore", async () => {
   const state = reactive({
     activeRole: "doctor" as const,
     feedback: null,
+    syncNotifications: [] as SyncNotification[],
     session: { authenticated: true, accountId: "doctor-1" },
     control: {
       profile: { firstName: "Вера", lastName: "Врач" },
@@ -49,6 +53,7 @@ vi.mock("../src/appStore", async () => {
     searchDoctorDirectory: directoryMocks.searchDoctorDirectory,
     searchPetDirectory: directoryMocks.searchPetDirectory,
     setDoctorMedicalState: (medical: MedicalSnapshot) => { state.medical = medical; },
+    setDoctorSyncNotifications: (notifications: SyncNotification[]) => { state.syncNotifications = notifications; },
   };
 });
 
@@ -161,6 +166,13 @@ async function setMedical(medical: MedicalSnapshot) {
   store.setDoctorMedicalState(medical);
 }
 
+async function setSyncNotifications(notifications: SyncNotification[]) {
+  const store = await import("../src/appStore") as typeof import("../src/appStore") & {
+    setDoctorSyncNotifications: (value: SyncNotification[]) => void;
+  };
+  store.setDoctorSyncNotifications(notifications);
+}
+
 async function mountAt(path: string, scenarioId: string) {
   const router = createRouter({
     history: createMemoryHistory(),
@@ -182,6 +194,7 @@ beforeEach(async () => {
   vi.clearAllMocks();
   localStorage.clear();
   await setMedical(snapshot());
+  await setSyncNotifications([]);
   directoryMocks.loadDoctorPetAccesses.mockResolvedValue(accessPage([doctorAccess()]));
   directoryMocks.lookupPetDirectory.mockImplementation(async (petId: string) => ({
     petId,
@@ -964,6 +977,149 @@ describe("Doctor pages", () => {
         },
       }),
     }));
+  });
+
+  it("validates and saves structured laboratory studies", async () => {
+    const wrapper = await mountAt("/doctor/pets/pet-1", "doctor-pet-detail");
+    await flushPromises();
+    await wrapper.findAll(".encounter-taxonomy label").find((label) => label.text() === "Не ест")!
+      .get("input").trigger("change");
+    await wrapper.findAll(".encounter-outcome .check-row")
+      .find((option) => option.text() === "В стадии наблюдения")!
+      .get("input").trigger("change");
+    await wrapper.get<HTMLSelectElement>(".encounter-add-section select").setValue("laboratory-tests");
+
+    const laboratoryEditor = wrapper.getComponent(LaboratoryTestsEditor);
+    expect(laboratoryEditor.exists()).toBe(true);
+    await wrapper.get('button[title="Сохранить запись"]').trigger("click");
+    expect(repositoryMocks.saveEncounter).not.toHaveBeenCalled();
+    expect(laboratoryEditor.get('[role="alert"]').text()).toContain("Добавьте хотя бы одно");
+
+    await laboratoryEditor.findAll("button")
+      .find((button) => button.text().includes("Добавить исследование"))!
+      .trigger("click");
+    await flushPromises();
+    laboratoryEditor.findAllComponents(AppCatalogCombobox)[0]!.vm
+      .$emit("update:selectedIds", ["lab.study.cbc"]);
+    await flushPromises();
+    laboratoryEditor.findAllComponents(AppCatalogCombobox)[1]!.vm
+      .$emit("update:selectedIds", ["lab.indicator.cbc.001"]);
+    await flushPromises();
+    const laboratoryField = laboratoryEditor.findAll("label")
+      .find((label) => label.find("span").exists() && label.get("span").text() === "Лаборатория")!;
+    await laboratoryField.get("input").setValue("Ветлаб");
+    await laboratoryEditor.get(".laboratory-results tbody tr input").setValue("42");
+
+    await wrapper.get('button[title="Сохранить запись"]').trigger("click");
+    await flushPromises();
+    expect(repositoryMocks.saveEncounter).toHaveBeenCalledWith(expect.objectContaining({
+      petId: "pet-1",
+      sections: expect.objectContaining({
+        "laboratory-tests": {
+          studies: [expect.objectContaining({
+            typeId: "lab.study.cbc",
+            typeName: "Общеклинический анализ крови",
+            mode: "panel",
+            laboratory: "Ветлаб",
+            results: [expect.objectContaining({ indicatorId: "lab.indicator.cbc.001", result: "42" })],
+          })],
+        },
+      }),
+    }));
+  });
+
+  it("restores structured laboratory studies in the inline editor", async () => {
+    const laboratoryRecord: MedicalRecordDraft = {
+      ...medicalRecord,
+      sections: {
+        ...medicalRecord.sections,
+        "laboratory-tests": {
+          kind: "laboratory-tests",
+          templateVersion: "laboratory-tests-v1",
+          value: {
+            studies: [{
+              id: "123e4567-e89b-12d3-a456-426614174000",
+              date: "2026-07-21",
+              typeId: "lab.study.cbc",
+              typeName: "Общеклинический анализ крови",
+              mode: "panel",
+              laboratory: "Ветлаб",
+              results: [{ indicatorId: "lab.indicator.cbc.001", indicatorName: "Гематокрит", unit: "%", result: "42" }],
+            }],
+          },
+          authorAccountId: "doctor-1",
+          authorDisplayName: "Вера Врач",
+          updatedAt: "2026-07-21T10:00:00.000Z",
+        },
+      },
+    };
+    await setMedical(snapshot(undefined, { records: [laboratoryRecord] }));
+    const wrapper = await mountAt("/doctor/pets/pet-1", "doctor-pet-detail");
+    await flushPromises();
+    await wrapper.get(".medical-record-edit").trigger("click");
+    const editor = wrapper.get(".encounter-editor-inline").getComponent(LaboratoryTestsEditor);
+
+    expect(editor.findAll(".laboratory-study-card")).toHaveLength(1);
+    expect(editor.get<HTMLInputElement>(".laboratory-metadata label:nth-child(3) input").element.value).toBe("Ветлаб");
+    await editor.findAll("button").find((button) => button.text().includes("Добавить исследование"))!.trigger("click");
+    await flushPromises();
+    expect(editor.findAll(".laboratory-study-card")).toHaveLength(2);
+  });
+
+  it("recovers structured laboratory studies from an offline draft", async () => {
+    await setSyncNotifications([{
+      notificationId: "notification-laboratory",
+      accountId: "doctor-1",
+      operationId: "operation-laboratory",
+      entityId: "record-laboratory",
+      commandAction: "medical.record.created",
+      code: "VALIDATION_FAILED",
+      reasonKey: "invalid",
+      diagnosticId: "diagnostic-laboratory",
+      createdAt: "2026-08-15T10:00:00.000Z",
+      action: "return",
+      relatedRoute: "/doctor/pets/pet-1",
+      localDraft: {
+        operationId: "operation-laboratory",
+        type: "record.create",
+        activeRole: "doctor",
+        entityId: "record-laboratory",
+        createdAt: "2026-08-15T10:00:00.000Z",
+        payload: {
+          input: {
+            petId: "pet-1",
+            encounterDate: "2026-08-15",
+            sections: {
+              "what-happened": { selectedIds: ["problem.digestive.1"], comment: "Не ест" },
+              "laboratory-tests": {
+                studies: [{
+                  id: "123e4567-e89b-12d3-a456-426614174000",
+                  date: "2026-08-15",
+                  typeId: "lab.study.cbc",
+                  typeName: "Общеклинический анализ крови",
+                  mode: "panel",
+                  laboratory: "Ветлаб",
+                  results: [{ indicatorId: "lab.indicator.cbc.001", indicatorName: "Гематокрит", unit: "%", result: "42" }],
+                }],
+              },
+              outcome: { selectedIds: ["outcome.observation"], comment: "" },
+            },
+          },
+        },
+      },
+    }]);
+
+    const wrapper = await mountAt(
+      "/doctor/pets/pet-1?recover=notification-laboratory",
+      "doctor-pet-detail",
+    );
+    await flushPromises();
+
+    const editor = wrapper.get(".doctor-pet-detail > .encounter-editor").getComponent(LaboratoryTestsEditor);
+    expect(editor.findAll(".laboratory-study-card")).toHaveLength(1);
+    expect(editor.get<HTMLInputElement>('input[aria-label="Название исследования"]').element.value)
+      .toBe("Общеклинический анализ крови");
+    expect(wrapper.text()).toContain("Черновик восстановлен");
   });
 
   it("validates and saves the five-tab therapeutic appointment template", async () => {

--- a/tests/laboratory.spec.ts
+++ b/tests/laboratory.spec.ts
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Klinok application
+
+import { describe, expect, it } from "vitest";
+import { LABORATORY_STUDY_CATALOG, laboratoryStudyTypeById, normalizeLaboratoryTestsValue } from "@klinok/contracts";
+
+const id = "123e4567-e89b-12d3-a456-426614174000";
+const base = { id, date: "2026-08-15", laboratory: " Ветлаб ", technician: " Иванов ", equipment: " ", comment: " ok " };
+
+describe("structured laboratory studies", () => {
+  it("keeps catalog identifiers unique, including duplicate names with different units", () => {
+    const studies = new Set(LABORATORY_STUDY_CATALOG.map((study) => study.id));
+    const indicators = LABORATORY_STUDY_CATALOG.flatMap((study) => study.indicators);
+    expect(studies.size).toBe(LABORATORY_STUDY_CATALOG.length);
+    expect(new Set(indicators.map((item) => item.id)).size).toBe(indicators.length);
+    expect(indicators.filter((item) => item.name === "Ретикулоциты").map((item) => item.unit)).toEqual(["%", "×10⁹/л"]);
+    expect(LABORATORY_STUDY_CATALOG.some((study) => study.mode === "narrative")).toBe(true);
+    expect(LABORATORY_STUDY_CATALOG.some((study) => study.mode === "infection")).toBe(true);
+  });
+
+  it("trims and canonicalizes panel snapshots from stable catalog ids", () => {
+    const type = laboratoryStudyTypeById("lab.study.cbc")!;
+    const indicator = type.indicators[0]!;
+    const value = normalizeLaboratoryTestsValue({ studies: [{ ...base, typeId: type.id, typeName: "forged", mode: "panel", results: [{ indicatorId: indicator.id, indicatorName: "forged", unit: "forged", result: " 42 ", reference: " 10–50 " }] }] }, "2026-08-15");
+    expect(value.studies[0]).toMatchObject({ laboratory: "Ветлаб", technician: "Иванов", typeName: type.name, mode: "panel", results: [{ indicatorName: indicator.name, unit: indicator.unit, result: "42", reference: "10–50" }] });
+  });
+
+  it("normalizes narrative and infection modes", () => {
+    const narrative = LABORATORY_STUDY_CATALOG.find((study) => study.mode === "narrative")!;
+    const infection = laboratoryStudyTypeById("lab.study.infection")!;
+    expect(normalizeLaboratoryTestsValue({ studies: [{ ...base, typeId: narrative.id, mode: "narrative", result: " описание " }] }).studies[0]).toMatchObject({ mode: "narrative", result: "описание" });
+    expect(normalizeLaboratoryTestsValue({ studies: [{ ...base, id: "223e4567-e89b-12d3-a456-426614174000", typeId: infection.id, mode: "infection", infection: " чума ", method: "ПЦР", result: "negative" }] }).studies[0]).toMatchObject({ mode: "infection", infection: "чума", result: "negative" });
+  });
+
+  it.each([
+    [{ studies: [] }, "Добавьте"],
+    [{ studies: [{ ...base, date: "2099-01-01", typeId: "lab.study.cbc", mode: "panel", results: [] }] }, "дату"],
+    [{ studies: [{ ...base, typeId: "unknown", mode: "panel", results: [] }] }, "справочника"],
+    [{ studies: [{ ...base, laboratory: "", typeId: "lab.study.cbc", mode: "panel", results: [] }] }, "лабораторию"],
+  ])("rejects malformed values", (value, message) => {
+    expect(() => normalizeLaboratoryTestsValue(value)).toThrow(message);
+  });
+});

--- a/tests/laboratoryComparison.spec.ts
+++ b/tests/laboratoryComparison.spec.ts
@@ -1,0 +1,98 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Klinok application
+
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import AppCatalogCombobox from "../src/components/AppCatalogCombobox.vue";
+import AppPaginator from "../src/components/AppPaginator.vue";
+import LaboratoryComparison from "../src/components/LaboratoryComparison.vue";
+import type { MedicalRecordDraft } from "../src/repositories/types";
+
+function record(laboratorySection: unknown, recordId = "record-1"): MedicalRecordDraft {
+  return {
+    recordId,
+    petId: "pet-1",
+    revision: 1,
+    authorAccountId: "doctor-1",
+    authorDisplayName: "Иван Врач",
+    encounterDate: "2026-08-15",
+    title: "Приём",
+    text: "Осмотр",
+    sections: { "laboratory-tests": laboratorySection } as MedicalRecordDraft["sections"],
+    createdAt: "2026-08-15T10:00:00.000Z",
+    updatedAt: "2026-08-15T10:00:00.000Z",
+  };
+}
+
+describe("LaboratoryComparison", () => {
+  it.each([
+    ["legacy free text", { kind: "laboratory-tests", templateVersion: "free-text-v0", value: { text: "Старый текст" } }],
+    ["malformed structured data", { kind: "laboratory-tests", templateVersion: "laboratory-tests-v1", value: {} }],
+  ])("silently skips %s", (_description, section) => {
+    const wrapper = mount(LaboratoryComparison, {
+      props: { records: [record(section)], confirmedIds: new Set<string>() },
+    });
+
+    expect(wrapper.find(".laboratory-comparison").exists()).toBe(false);
+  });
+
+  it("keeps valid structured studies when unsupported records are also present", async () => {
+    const structured = {
+      kind: "laboratory-tests",
+      templateVersion: "laboratory-tests-v1",
+      value: {
+        studies: [{
+          id: "123e4567-e89b-12d3-a456-426614174000",
+          date: "2026-08-15",
+          typeId: "lab.study.cbc",
+          typeName: "Общеклинический анализ крови",
+          mode: "panel",
+          laboratory: "Ветлаб",
+          results: [{ indicatorId: "lab.indicator.cbc.001", indicatorName: "Гематокрит", unit: "%", result: "42" }],
+        }],
+      },
+    };
+    const secondStructured = {
+      ...structured,
+      value: { studies: [{
+        ...structured.value.studies[0],
+        id: "223e4567-e89b-12d3-a456-426614174000",
+        date: "2026-08-14",
+        results: [{
+          indicatorId: "lab.indicator.cbc.002",
+          indicatorName: "Гемоглобин",
+          unit: "г/л",
+          result: "145",
+          reference: "120–180",
+        }],
+      }] },
+    };
+    const legacy = { kind: "laboratory-tests", templateVersion: "free-text-v0", value: { text: "Старый текст" } };
+    const wrapper = mount(LaboratoryComparison, {
+      props: {
+        records: [record(legacy, "legacy"), record(structured), record(secondStructured, "record-2")],
+        confirmedIds: new Set(["record-2"]),
+      },
+    });
+
+    expect(wrapper.get(".laboratory-comparison").text()).toContain("Сравнение лабораторных показателей");
+    wrapper.getComponent(AppCatalogCombobox).vm.$emit("update:selectedIds", [
+      "lab.indicator.cbc.001",
+      "lab.indicator.cbc.002",
+    ]);
+    await wrapper.vm.$nextTick();
+
+    const comparison = wrapper.get(".laboratory-comparison");
+    expect(comparison.findAll("tbody tr")).toHaveLength(2);
+    expect(comparison.text()).toContain("14.08.2026");
+    expect(comparison.text()).toContain("Ожидает подтверждения");
+    expect(comparison.text()).toContain("Подтверждено");
+    expect(comparison.text()).toContain("Реф.: 120–180");
+    expect(comparison.findAll("tbody td span").map((cell) => cell.text())).toEqual(["—", "—"]);
+    expect(comparison.find(".app-paginator").exists()).toBe(true);
+    wrapper.getComponent(AppPaginator).vm.$emit("update:page", 1);
+    wrapper.getComponent(AppPaginator).vm.$emit("update:pageSize", 20);
+    await wrapper.vm.$nextTick();
+  });
+});

--- a/tests/laboratoryTestsEditor.spec.ts
+++ b/tests/laboratoryTestsEditor.spec.ts
@@ -1,0 +1,117 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Klinok application
+
+import { flushPromises, mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import {
+  LABORATORY_STUDY_CATALOG,
+  laboratoryStudyTypeById,
+  type LaboratoryTestsSectionValue,
+} from "@klinok/contracts";
+import AppCatalogCombobox from "../src/components/AppCatalogCombobox.vue";
+import LaboratoryTestsEditor from "../src/components/LaboratoryTestsEditor.vue";
+
+describe("LaboratoryTestsEditor", () => {
+  it("adds, changes, confirms destructive edits, and removes every study mode", async () => {
+    let current: LaboratoryTestsSectionValue = { studies: [] };
+    let updateModel: (value: LaboratoryTestsSectionValue) => void = () => undefined;
+    const wrapper = mount(LaboratoryTestsEditor, {
+      props: {
+        modelValue: current,
+        encounterDate: "2026-08-15",
+        errors: "Добавьте хотя бы одно лабораторное исследование.",
+        "onUpdate:modelValue": (value: LaboratoryTestsSectionValue) => updateModel(value),
+      },
+    });
+    updateModel = (value: LaboratoryTestsSectionValue) => {
+      current = value;
+      void wrapper.setProps({ modelValue: value });
+    };
+
+    expect(wrapper.get('[role="alert"]').text()).toContain("Добавьте хотя бы одно");
+    await wrapper.findAll("button").find((button) => button.text().includes("Добавить исследование"))!.trigger("click");
+    await flushPromises();
+    expect(current.studies).toHaveLength(1);
+    expect(current.studies[0]).toMatchObject({ date: "2026-08-15", mode: "panel", results: [] });
+
+    let typePicker = wrapper.findAllComponents(AppCatalogCombobox)[0]!;
+    typePicker.vm.$emit("update:selectedIds", ["unknown"]);
+    typePicker.vm.$emit("update:selectedIds", ["lab.study.cbc"]);
+    await flushPromises();
+    expect(current.studies[0]).toMatchObject({ typeId: "lab.study.cbc", mode: "panel" });
+
+    typePicker = wrapper.findAllComponents(AppCatalogCombobox)[0]!;
+    typePicker.vm.$emit("update:selectedIds", ["lab.study.cbc"]);
+    const cbc = laboratoryStudyTypeById("lab.study.cbc")!;
+    const [hematocrit, hemoglobin] = cbc.indicators;
+    const indicatorPicker = wrapper.findAllComponents(AppCatalogCombobox)[1]!;
+    indicatorPicker.vm.$emit("update:selectedIds", [hematocrit!.id]);
+    await flushPromises();
+    expect(current.studies[0]).toMatchObject({
+      results: [{ indicatorId: hematocrit!.id, indicatorName: hematocrit!.name, unit: hematocrit!.unit, result: "" }],
+    });
+
+    const laboratory = wrapper.findAll("label")
+      .find((label) => label.find("span").exists() && label.get("span").text() === "Лаборатория")!;
+    const metadataField = (label: string) => wrapper.findAll(".laboratory-metadata label")
+      .find((candidate) => candidate.find("span").exists() && candidate.get("span").text() === label)!;
+    await metadataField("Дата исследования").get("input").setValue("2026-08-14");
+    await laboratory.get("input").setValue("Ветлаб");
+    await metadataField("ФИО лаборанта").get("input").setValue("Иванов");
+    await metadataField("Оборудование").get("input").setValue("Анализатор");
+    await wrapper.get("textarea.medical-card-comment").setValue("Натощак");
+    const resultInputs = wrapper.get(".laboratory-results tbody tr").findAll("input");
+    await resultInputs[0]!.setValue("42");
+    await resultInputs[1]!.setValue("35–55");
+
+    indicatorPicker.vm.$emit("update:selectedIds", [hemoglobin!.id]);
+    await flushPromises();
+    let dialog = wrapper.get('[role="alertdialog"]');
+    expect(dialog.text()).toContain("Удалить заполненные данные?");
+    await dialog.get(".outline-action").trigger("click");
+    expect(current.studies[0]).toMatchObject({ results: [{ indicatorId: hematocrit!.id }] });
+
+    wrapper.findAllComponents(AppCatalogCombobox)[1]!.vm.$emit("update:selectedIds", [hemoglobin!.id]);
+    await flushPromises();
+    dialog = wrapper.get('[role="alertdialog"]');
+    await dialog.get(".danger").trigger("click");
+    expect(current.studies[0]).toMatchObject({ results: [{ indicatorId: hemoglobin!.id, result: "" }] });
+
+    const narrative = LABORATORY_STUDY_CATALOG.find((study) => study.mode === "narrative")!;
+    wrapper.findAllComponents(AppCatalogCombobox)[0]!.vm.$emit("update:selectedIds", [narrative.id]);
+    await flushPromises();
+    await wrapper.get('[role="alertdialog"] .danger').trigger("click");
+    await flushPromises();
+    expect(current.studies[0]).toMatchObject({ typeId: narrative.id, mode: "narrative", result: "" });
+    expect("results" in current.studies[0]!).toBe(false);
+    await wrapper.get(".laboratory-study-card > label textarea").setValue("Описание результата");
+
+    wrapper.findAllComponents(AppCatalogCombobox)[0]!.vm.$emit("update:selectedIds", ["lab.study.infection"]);
+    await flushPromises();
+    await wrapper.get('[role="alertdialog"] .danger').trigger("click");
+    await flushPromises();
+    expect(current.studies[0]).toMatchObject({
+      typeId: "lab.study.infection",
+      mode: "infection",
+      infection: "",
+      method: "ПЦР",
+      result: "negative",
+    });
+    expect(wrapper.get(".laboratory-infection select").findAll("option")).toHaveLength(5);
+    await wrapper.get(".laboratory-infection input[required]").setValue("Чума плотоядных");
+
+    await wrapper.get('button[title="Удалить исследование"]').trigger("click");
+    await flushPromises();
+    await wrapper.get('[role="alertdialog"] .danger').trigger("click");
+    await flushPromises();
+    expect(current.studies).toHaveLength(0);
+
+    await wrapper.findAll("button").find((button) => button.text().includes("Добавить исследование"))!.trigger("click");
+    await flushPromises();
+    await wrapper.get('button[title="Удалить исследование"]').trigger("click");
+    await flushPromises();
+    expect(current.studies).toHaveLength(0);
+    expect(wrapper.find('[role="alertdialog"]').exists()).toBe(false);
+  });
+});

--- a/tests/medicalRecordEntry.spec.ts
+++ b/tests/medicalRecordEntry.spec.ts
@@ -69,6 +69,76 @@ const record: MedicalRecordDraft = {
 };
 
 describe("MedicalRecordEntry", () => {
+  it("renders panel, narrative, and infection laboratory studies", () => {
+    const wrapper = mount(MedicalRecordEntry, {
+      props: {
+        record: {
+          ...record,
+          sections: {
+            ...record.sections,
+            "laboratory-tests": {
+              kind: "laboratory-tests",
+              templateVersion: "laboratory-tests-v1",
+              value: {
+                studies: [
+                  {
+                    id: "123e4567-e89b-12d3-a456-426614174000",
+                    date: "2026-07-20",
+                    typeId: "lab.study.cbc",
+                    typeName: "Общеклинический анализ крови",
+                    mode: "panel",
+                    laboratory: "Ветлаб",
+                    technician: "Иванов",
+                    equipment: "Анализатор",
+                    comment: "Натощак",
+                    results: [{ indicatorId: "lab.indicator.cbc.001", indicatorName: "Гематокрит", unit: "%", result: "42", reference: "35–55" }],
+                  },
+                  {
+                    id: "223e4567-e89b-12d3-a456-426614174000",
+                    date: "2026-07-21",
+                    typeId: "lab.study.narrative.001",
+                    typeName: "Микроскопия",
+                    mode: "narrative",
+                    laboratory: "Ветлаб",
+                    result: "Патологий не обнаружено",
+                  },
+                  {
+                    id: "323e4567-e89b-12d3-a456-426614174000",
+                    date: "2026-07-21",
+                    typeId: "lab.study.infection",
+                    typeName: "Исследование на инфекцию",
+                    mode: "infection",
+                    laboratory: "Ветлаб",
+                    infection: "Чума плотоядных",
+                    method: "ПЦР",
+                    result: "positive",
+                  },
+                ],
+              },
+              authorAccountId: "doctor-1",
+              authorDisplayName: "Вера Врач",
+              updatedAt: "2026-07-21T12:00:00.000Z",
+            },
+          },
+        },
+        mode: "details",
+        confirmed: false,
+        open: true,
+      },
+    });
+
+    const history = wrapper.get(".laboratory-history");
+    expect(history.findAll(".laboratory-history-study")).toHaveLength(3);
+    expect(history.text()).toContain("20.07.2026 · Общеклинический анализ крови");
+    expect(history.text()).toContain("Иванов");
+    expect(history.text()).toContain("Анализатор");
+    expect(history.text()).toContain("35–55");
+    expect(history.text()).toContain("Патологий не обнаружено");
+    expect(history.text()).toContain("Чума плотоядных");
+    expect(history.text()).toContain("Положительно");
+    expect(history.text()).toContain("Натощак");
+  });
+
   it.each([
     ["well.1", "Всё хорошо", "well"],
     ["problem.digestive.1", "Не всё хорошо", "problem"],

--- a/tests/repositoryFacade.spec.ts
+++ b/tests/repositoryFacade.spec.ts
@@ -280,7 +280,7 @@ describe("Klinok repository facade", () => {
     } as unknown as MedicalEncounterInput;
     await repository.executeOffline({ type: "record.create", entityId: "record-offline", payload: { input: encounter, title: "Приём" } });
     await repository.executeOffline({ type: "record.update", entityId: "record-offline", expectedRevision: 1, payload: {
-      input: { ...encounter, sections: { ...encounter.sections, "general-data": { text: "Свободный текст" }, vaccination: { text: "Нет" }, "therapeutic-appointment": { text: "Покой" } } },
+      input: { ...encounter, sections: { ...encounter.sections, "general-data": { text: "Свободный текст" }, vaccination: { text: "Нет" }, "therapeutic-appointment": { text: "Покой" }, "laboratory-tests": { text: "Старый лабораторный текст" } } },
     } });
 
     const queued = offlineState.commands.map((item) => item.command);
@@ -299,6 +299,8 @@ describe("Klinok repository facade", () => {
         diagnosis: { templateVersion: "diagnosis-v2" },
       },
     });
+    expect(repository.current.medical.records.find((record) => record.recordId === "record-offline")
+      ?.sections["laboratory-tests"]).toBeUndefined();
     await expect(repository.syncStatus()).resolves.toMatchObject({ pendingCount: 4, connectionState: "disconnected" });
     expect(medicalListener).toHaveBeenCalled();
     expect(syncListener).toHaveBeenCalled();


### PR DESCRIPTION
### Motivation

- Replace the old `laboratory-tests` free-text flow with a structured, repeatable `laboratory-tests-v1` template so encounters can contain multiple typed studies (panel / narrative / infection) with canonicalized catalog snapshots and UUIDs preserved across edits and offline recovery.
- Provide a shared longitudinal comparison view for panel indicators to help doctors and owners review trends across confirmed and pending records without requiring DB migrations or admin UIs.

### Description

- Add a typed laboratory catalog, study types, indicators, and normalization/validation logic in `packages/contracts/src/laboratory.ts` and export helpers from `packages/contracts/src/index.ts` so catalog names/units are canonicalized at the command boundary.
- Implement server-side canonicalization and validation in `api-node/src/commands.ts` using `normalizeLaboratoryTestsValue`, and wire `laboratory-tests-v1` into section `templateVersion` selection and medical-encounter input validation.
- Add a repeatable editor component `src/components/LaboratoryTestsEditor.vue` with catalog-only study and indicator pickers, mode-specific inputs, result table, UUID generation, and destructive-change confirmation, and integrate it into the encounter editor (`src/components/EncounterEditorForm.vue` and `src/screens/DoctorScreen.vue`).
- Render structured studies in history (`src/components/MedicalRecordEntry.vue`), add a shared paginated comparison component `src/components/LaboratoryComparison.vue` and include it on owner and doctor medical-card screens, and update styles in `src/styles.css`.
- Extend `AppCatalogCombobox.vue` with an `allowCustom` prop (default `true`) and use `allowCustom=false` for laboratory pickers; update repository/types and optimistic record construction to support the new structured section types.
- Add unit tests `tests/laboratory.spec.ts` covering catalog uniqueness, duplicate indicator names with different units, panel/narrative/infection normalization, trimming/canonicalization, and malformed input rejection.

### Testing

- Ran unit and integration test suites with `npm test`, which completed successfully.
- Ran coverage with `npm run coverage` and linter check with `npm run lint:check`, both of which succeeded.
- Performed full builds with `npm run build` (UI and API), which succeeded; `git diff --check` and ESLint checks were clean in the working tree.
- Attempted the Compose e2e smoke `npm run test:e2e:compose` but it could not run in this environment because Docker is not available, so the compose smoke step was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a804e5ceac48321be795ef9ceedddc5)