### PR TITLE
Терапевтический приём: структурированное read-only представление без вкладок

### DIFF
--- a/e2e/operational.spec.ts
+++ b/e2e/operational.spec.ts
@@ -1056,7 +1056,12 @@ test("fresh provisioning, Doctor approval, grant, draft, and confirmation", asyn
   const ownerTherapeutic = ownerRecord.locator(".encounter-history-section").filter({
     has: ownerPage.getByRole("heading", { name: "Терапевтический приём", exact: true }),
   });
-  await expect(ownerTherapeutic.getByRole("tab")).toHaveCount(5);
+  await expect(ownerTherapeutic.getByRole("tablist")).toHaveCount(0);
+  await expect(ownerTherapeutic.locator(".therapeutic-history-block > h4")).toHaveText([
+    "Анамнез болезни",
+    "Рекомендации",
+    "Назначения",
+  ]);
   await expect(ownerTherapeutic.getByText("Проблема 1: Контрольный осмотр", { exact: true })).toBeVisible();
   const ownerProblem = ownerTherapeutic.locator(".therapeutic-history-problems article").filter({ hasText: "Контрольный осмотр" });
   await expect(ownerProblem.getByText("Как давно началось", { exact: true })).toBeVisible();
@@ -1076,9 +1081,7 @@ test("fresh provisioning, Doctor approval, grant, draft, and confirmation", asyn
   expect(await historyFont(ownerProblem.locator("dd").first()))
     .toEqual(await historyFont(ownerWhatHappened.locator("li").first()));
   expect(await ownerProblem.locator("dd").first().evaluate((element) => getComputedStyle(element).textAlign)).toBe("left");
-  await ownerTherapeutic.getByRole("tab", { name: "Рекомендации" }).click();
   await expect(ownerTherapeutic.getByText("Повторный осмотр через неделю", { exact: true })).toBeVisible();
-  await ownerTherapeutic.getByRole("tab", { name: "Назначения" }).click();
   await expect(ownerTherapeutic.getByText("Щадящий режим", { exact: true })).toBeVisible();
   await expect(ownerRecord.getByText("14.3 кг", { exact: true })).toBeVisible();
   const profileWeight = ownerPage.locator(".pet-profile-view-fields > div").filter({ hasText: "Вес" });

--- a/src/components/TherapeuticAppointmentView.vue
+++ b/src/components/TherapeuticAppointmentView.vue
@@ -3,67 +3,27 @@
 // All rights reserved.
 // This file is a part of Klinok application
 
-import { computed, nextTick, ref, useId } from "vue";
+import { computed } from "vue";
 import {
   DISEASE_ANAMNESIS_CATEGORIES,
   EXAMINATION_CATEGORIES,
   LIFE_ANAMNESIS_CATEGORIES,
-  THERAPEUTIC_TABS,
   therapeuticOptionLabel,
   therapeuticSelectionDetails,
 } from "../therapeuticAppointment";
-import type { TherapeuticTab } from "../therapeuticAppointment";
 import type { TherapeuticAppointmentSectionValue, TherapeuticProblemValue } from "../repositories/types";
 
 const props = defineProps<{ value: TherapeuticAppointmentSectionValue }>();
-const activeTab = ref<TherapeuticTab>(firstPopulatedTab(props.value));
-const tabButtons = ref<HTMLButtonElement[]>([]);
-const baseId = useId();
 const diseaseDetails = computed(() => therapeuticSelectionDetails(props.value.diseaseAnamnesis.selectedIds, DISEASE_ANAMNESIS_CATEGORIES));
 const lifeDetails = computed(() => therapeuticSelectionDetails(props.value.lifeAnamnesis.selectedIds, LIFE_ANAMNESIS_CATEGORIES));
 const examinationDetails = computed(() => therapeuticSelectionDetails(props.value.examination.selectedIds, EXAMINATION_CATEGORIES));
 const hasLife = computed(() => Boolean(props.value.lifeAnamnesis.text || lifeDetails.value.length
   || props.value.lifeAnamnesis.currentMedications || props.value.lifeAnamnesis.allergies));
-
-function firstPopulatedTab(value: TherapeuticAppointmentSectionValue): TherapeuticTab {
-  const populatedTabs: Record<TherapeuticTab, boolean> = {
-    disease: Boolean(value.diseaseAnamnesis.text || value.diseaseAnamnesis.problems.length
-      || value.diseaseAnamnesis.selectedIds.length),
-    life: Boolean(value.lifeAnamnesis.text || value.lifeAnamnesis.selectedIds.length
-      || value.lifeAnamnesis.currentMedications || value.lifeAnamnesis.allergies),
-    examination: Boolean(value.examination.text || value.examination.selectedIds.length),
-    recommendations: Boolean(value.recommendations),
-    prescriptions: Boolean(value.prescriptions),
-  };
-  return THERAPEUTIC_TABS.find((tab) => populatedTabs[tab.id])?.id ?? "disease";
-}
-
-function activateTab(tab: TherapeuticTab, focus = false) {
-  activeTab.value = tab;
-  if (focus) {
-    const index = THERAPEUTIC_TABS.findIndex((candidate) => candidate.id === tab);
-    void nextTick(() => tabButtons.value[index]?.focus());
-  }
-}
-
-function handleTabKeydown(event: KeyboardEvent, index: number) {
-  let target = index;
-  if (["ArrowRight", "ArrowDown"].includes(event.key)) target = (index + 1) % THERAPEUTIC_TABS.length;
-  else if (["ArrowLeft", "ArrowUp"].includes(event.key)) target = (index - 1 + THERAPEUTIC_TABS.length) % THERAPEUTIC_TABS.length;
-  else if (event.key === "Home") target = 0;
-  else if (event.key === "End") target = THERAPEUTIC_TABS.length - 1;
-  else return;
-  event.preventDefault();
-  activateTab(THERAPEUTIC_TABS[target]!.id, true);
-}
-
-function tabId(tab: TherapeuticTab) {
-  return `${baseId}-${tab}-view-tab`;
-}
-
-function panelId(tab: TherapeuticTab) {
-  return `${baseId}-${tab}-view-panel`;
-}
+const populatedProblems = computed(() => props.value.diseaseAnamnesis.problems.filter((problem) =>
+  Boolean(problem.title || problemDetails(problem).length),
+));
+const hasDisease = computed(() => Boolean(props.value.diseaseAnamnesis.text || populatedProblems.value.length || diseaseDetails.value.length));
+const hasExamination = computed(() => Boolean(props.value.examination.text || examinationDetails.value.length));
 
 function problemDetails(problem: TherapeuticProblemValue): Array<{ label: string; value: string }> {
   return [
@@ -80,35 +40,17 @@ function problemDetails(problem: TherapeuticProblemValue): Array<{ label: string
 
 <template>
   <div class="therapeutic-appointment-view">
-    <div class="therapeutic-tabs" role="tablist" aria-label="Разделы терапевтического приёма">
-      <button
-        v-for="(tab, index) in THERAPEUTIC_TABS"
-        :id="tabId(tab.id)"
-        :key="tab.id"
-        :ref="(element) => { if (element) tabButtons[index] = element as HTMLButtonElement }"
-        type="button"
-        role="tab"
-        :aria-controls="panelId(tab.id)"
-        :aria-selected="activeTab === tab.id"
-        :tabindex="activeTab === tab.id ? 0 : -1"
-        :class="{ active: activeTab === tab.id }"
-        @click="activateTab(tab.id)"
-        @keydown="handleTabKeydown($event, index)"
-      >{{ tab.label }}</button>
-    </div>
-
     <section
-      :id="panelId('disease')"
-      class="therapeutic-tab-panel therapeutic-history-block"
-      role="tabpanel"
-      :aria-labelledby="tabId('disease')"
-      :hidden="activeTab !== 'disease'"
+      v-if="hasDisease"
+      class="therapeutic-history-block"
     >
       <h4>Анамнез болезни</h4>
-      <p v-if="value.diseaseAnamnesis.text" class="therapeutic-history-text">{{ value.diseaseAnamnesis.text }}</p>
-      <div v-if="value.diseaseAnamnesis.problems.length" class="therapeutic-history-problems">
-        <article v-for="(problem, index) in value.diseaseAnamnesis.problems" :key="problem.id">
-          <h5>Проблема {{ index + 1 }}: {{ problem.title }}</h5>
+      <dl v-if="value.diseaseAnamnesis.text" class="therapeutic-history-values">
+        <div><dt>Комментарий</dt><dd class="therapeutic-history-text">{{ value.diseaseAnamnesis.text }}</dd></div>
+      </dl>
+      <div v-if="populatedProblems.length" class="therapeutic-history-problems">
+        <article v-for="(problem, index) in populatedProblems" :key="problem.id">
+          <h5>Проблема {{ index + 1 }}<template v-if="problem.title">: {{ problem.title }}</template></h5>
           <dl v-if="problemDetails(problem).length" class="therapeutic-history-values">
             <div v-for="detail in problemDetails(problem)" :key="detail.label"><dt>{{ detail.label }}</dt><dd>{{ detail.value }}</dd></div>
           </dl>
@@ -119,49 +61,39 @@ function problemDetails(problem: TherapeuticProblemValue): Array<{ label: string
       </dl>
     </section>
     <section
-      :id="panelId('life')"
-      class="therapeutic-tab-panel therapeutic-history-block"
-      role="tabpanel"
-      :aria-labelledby="tabId('life')"
-      :hidden="activeTab !== 'life'"
+      v-if="hasLife"
+      class="therapeutic-history-block"
     >
       <h4>Анамнез жизни</h4>
-      <p v-if="value.lifeAnamnesis.text" class="therapeutic-history-text">{{ value.lifeAnamnesis.text }}</p>
       <dl v-if="hasLife" class="therapeutic-history-values">
+        <div v-if="value.lifeAnamnesis.text"><dt>Комментарий</dt><dd class="therapeutic-history-text">{{ value.lifeAnamnesis.text }}</dd></div>
         <div v-for="detail in lifeDetails" :key="detail.key"><dt>{{ detail.label }}</dt><dd>{{ detail.value }}</dd></div>
         <div v-if="value.lifeAnamnesis.currentMedications"><dt>Получаемые препараты</dt><dd class="therapeutic-history-text">{{ value.lifeAnamnesis.currentMedications }}</dd></div>
         <div v-if="value.lifeAnamnesis.allergies"><dt>Аллергии</dt><dd class="therapeutic-history-text">{{ value.lifeAnamnesis.allergies }}</dd></div>
       </dl>
     </section>
     <section
-      :id="panelId('examination')"
-      class="therapeutic-tab-panel therapeutic-history-block"
-      role="tabpanel"
-      :aria-labelledby="tabId('examination')"
-      :hidden="activeTab !== 'examination'"
+      v-if="hasExamination"
+      class="therapeutic-history-block"
     >
       <h4>Осмотр</h4>
-      <p v-if="value.examination.text" class="therapeutic-history-text">{{ value.examination.text }}</p>
+      <dl v-if="value.examination.text" class="therapeutic-history-values">
+        <div><dt>Комментарий</dt><dd class="therapeutic-history-text">{{ value.examination.text }}</dd></div>
+      </dl>
       <dl v-if="examinationDetails.length" class="therapeutic-history-values">
         <div v-for="detail in examinationDetails" :key="detail.key"><dt>{{ detail.label }}</dt><dd>{{ detail.value }}</dd></div>
       </dl>
     </section>
     <section
-      :id="panelId('recommendations')"
-      class="therapeutic-tab-panel therapeutic-history-block"
-      role="tabpanel"
-      :aria-labelledby="tabId('recommendations')"
-      :hidden="activeTab !== 'recommendations'"
+      v-if="value.recommendations"
+      class="therapeutic-history-block"
     >
       <h4>Рекомендации</h4>
       <p v-if="value.recommendations" class="therapeutic-history-text">{{ value.recommendations }}</p>
     </section>
     <section
-      :id="panelId('prescriptions')"
-      class="therapeutic-tab-panel therapeutic-history-block"
-      role="tabpanel"
-      :aria-labelledby="tabId('prescriptions')"
-      :hidden="activeTab !== 'prescriptions'"
+      v-if="value.prescriptions"
+      class="therapeutic-history-block"
     >
       <h4>Назначения</h4>
       <p v-if="value.prescriptions" class="therapeutic-history-text">{{ value.prescriptions }}</p>

--- a/src/components/TherapeuticAppointmentView.vue
+++ b/src/components/TherapeuticAppointmentView.vue
@@ -19,9 +19,9 @@ const lifeDetails = computed(() => therapeuticSelectionDetails(props.value.lifeA
 const examinationDetails = computed(() => therapeuticSelectionDetails(props.value.examination.selectedIds, EXAMINATION_CATEGORIES));
 const hasLife = computed(() => Boolean(props.value.lifeAnamnesis.text || lifeDetails.value.length
   || props.value.lifeAnamnesis.currentMedications || props.value.lifeAnamnesis.allergies));
-const populatedProblems = computed(() => props.value.diseaseAnamnesis.problems.filter((problem) =>
-  Boolean(problem.title || problemDetails(problem).length),
-));
+const populatedProblems = computed(() => props.value.diseaseAnamnesis.problems
+  .map((problem) => ({ problem, details: problemDetails(problem) }))
+  .filter(({ problem, details }) => Boolean(problem.title || details.length)));
 const hasDisease = computed(() => Boolean(props.value.diseaseAnamnesis.text || populatedProblems.value.length || diseaseDetails.value.length));
 const hasExamination = computed(() => Boolean(props.value.examination.text || examinationDetails.value.length));
 
@@ -49,10 +49,10 @@ function problemDetails(problem: TherapeuticProblemValue): Array<{ label: string
         <div><dt>Комментарий</dt><dd class="therapeutic-history-text">{{ value.diseaseAnamnesis.text }}</dd></div>
       </dl>
       <div v-if="populatedProblems.length" class="therapeutic-history-problems">
-        <article v-for="(problem, index) in populatedProblems" :key="problem.id">
+        <article v-for="({ problem, details }, index) in populatedProblems" :key="problem.id">
           <h5>Проблема {{ index + 1 }}<template v-if="problem.title">: {{ problem.title }}</template></h5>
-          <dl v-if="problemDetails(problem).length" class="therapeutic-history-values">
-            <div v-for="detail in problemDetails(problem)" :key="detail.label"><dt>{{ detail.label }}</dt><dd>{{ detail.value }}</dd></div>
+          <dl v-if="details.length" class="therapeutic-history-values">
+            <div v-for="detail in details" :key="detail.label"><dt>{{ detail.label }}</dt><dd>{{ detail.value }}</dd></div>
           </dl>
         </article>
       </div>
@@ -65,7 +65,7 @@ function problemDetails(problem: TherapeuticProblemValue): Array<{ label: string
       class="therapeutic-history-block"
     >
       <h4>Анамнез жизни</h4>
-      <dl v-if="hasLife" class="therapeutic-history-values">
+      <dl class="therapeutic-history-values">
         <div v-if="value.lifeAnamnesis.text"><dt>Комментарий</dt><dd class="therapeutic-history-text">{{ value.lifeAnamnesis.text }}</dd></div>
         <div v-for="detail in lifeDetails" :key="detail.key"><dt>{{ detail.label }}</dt><dd>{{ detail.value }}</dd></div>
         <div v-if="value.lifeAnamnesis.currentMedications"><dt>Получаемые препараты</dt><dd class="therapeutic-history-text">{{ value.lifeAnamnesis.currentMedications }}</dd></div>
@@ -89,14 +89,14 @@ function problemDetails(problem: TherapeuticProblemValue): Array<{ label: string
       class="therapeutic-history-block"
     >
       <h4>Рекомендации</h4>
-      <p v-if="value.recommendations" class="therapeutic-history-text">{{ value.recommendations }}</p>
+      <p class="therapeutic-history-text">{{ value.recommendations }}</p>
     </section>
     <section
       v-if="value.prescriptions"
       class="therapeutic-history-block"
     >
       <h4>Назначения</h4>
-      <p v-if="value.prescriptions" class="therapeutic-history-text">{{ value.prescriptions }}</p>
+      <p class="therapeutic-history-text">{{ value.prescriptions }}</p>
     </section>
   </div>
 </template>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1265,11 +1265,11 @@ dd {
   .therapeutic-problem-fields { grid-template-columns: minmax(0, 1fr); }
 }
 .therapeutic-history-text { white-space: pre-wrap; overflow-wrap: anywhere; }
-.therapeutic-appointment-view { display: grid; gap: 12px; }
+.therapeutic-appointment-view { display: grid; gap: 14px; }
 .therapeutic-history-block { display: grid; min-width: 0; gap: 7px; }
 .therapeutic-history-problems { display: grid; gap: 7px; }
-.therapeutic-history-problems > article { display: grid; gap: 5px; padding: 8px; border: 1px solid var(--line); border-radius: 8px; }
-.therapeutic-history-values { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 7px 14px; margin: 0; }
+.therapeutic-history-problems > article { display: grid; gap: 5px; }
+.therapeutic-history-values { display: grid; gap: 7px; margin: 0; }
 .therapeutic-history-values > div { display: grid; min-width: 0; gap: 2px; font: inherit; }
 .therapeutic-history-values dt { color: var(--text-muted); font-size: 10px; font-weight: 600; }
 .therapeutic-history-values dd { min-width: 0; margin: 0; overflow-wrap: anywhere; text-align: left; }

--- a/tests/medicalRecordEntry.spec.ts
+++ b/tests/medicalRecordEntry.spec.ts
@@ -539,8 +539,10 @@ describe("MedicalRecordEntry", () => {
 
     const section = wrapper.findAll(".encounter-history-section")
       .find((candidate) => candidate.get("h3").text() === "Терапевтический приём")!;
-    expect(section.find('[role="tablist"]').exists()).toBe(false);
-    expect(section.find('button').exists()).toBe(false);
+    const therapeuticView = section.get(".therapeutic-appointment-view");
+    expect(therapeuticView.find('[role="tablist"]').exists()).toBe(false);
+    expect(therapeuticView.find('[role="tab"]').exists()).toBe(false);
+    expect(therapeuticView.find('[role="tabpanel"]').exists()).toBe(false);
     expect(section.findAll(".therapeutic-history-block > h4").map((heading) => heading.text())).toEqual([
       "Анамнез болезни", "Анамнез жизни", "Осмотр", "Рекомендации", "Назначения",
     ]);

--- a/tests/medicalRecordEntry.spec.ts
+++ b/tests/medicalRecordEntry.spec.ts
@@ -485,7 +485,7 @@ describe("MedicalRecordEntry", () => {
     expect(section.text()).toContain("04.08.2028");
   });
 
-  it("renders therapeutic history in the same accessible tabs as the editor", async () => {
+  it("renders every populated therapeutic history section as structured text", () => {
     const wrapper = mount(MedicalRecordEntry, {
       props: {
         record: {
@@ -497,7 +497,7 @@ describe("MedicalRecordEntry", () => {
               templateVersion: "therapeutic-appointment-v1",
               value: {
                 diseaseAnamnesis: {
-                  text: "Снижение аппетита со вчерашнего дня",
+                  text: "Снижение аппетита\nсо вчерашнего дня",
                   problems: [{
                     id: "problem-1",
                     title: "Не ест",
@@ -507,6 +507,11 @@ describe("MedicalRecordEntry", () => {
                     medicationIds: ["problem.medication.type.nsaid"],
                     medicationName: "Мелоксикам",
                     medicationDynamicsId: "problem.dynamics.positive",
+                  }, {
+                    id: "problem-2",
+                    title: "Вялость",
+                    onsetId: "problem.onset.today",
+                    medicationIds: [],
                   }],
                   selectedIds: ["disease.appetite.state.changed", "disease.appetite.change.absent"],
                 },
@@ -516,10 +521,7 @@ describe("MedicalRecordEntry", () => {
                   currentMedications: "Не получает",
                   allergies: "Не выявлены",
                 },
-                examination: {
-                  text: "Контактен",
-                  selectedIds: ["exam.general.state.good"],
-                },
+                examination: { text: "Контактен", selectedIds: ["exam.general.state.good"] },
                 recommendations: "Контроль через неделю",
                 prescriptions: "Диетический корм",
               },
@@ -537,51 +539,21 @@ describe("MedicalRecordEntry", () => {
 
     const section = wrapper.findAll(".encounter-history-section")
       .find((candidate) => candidate.get("h3").text() === "Терапевтический приём")!;
-    const tabs = section.findAll<HTMLButtonElement>('[role="tab"]');
-    const panels = section.findAll('[role="tabpanel"]');
-    expect(tabs.map((tab) => tab.text())).toEqual([
-      "Анамнез болезни",
-      "Анамнез жизни",
-      "Осмотр",
-      "Рекомендации",
-      "Назначения",
+    expect(section.find('[role="tablist"]').exists()).toBe(false);
+    expect(section.find('button').exists()).toBe(false);
+    expect(section.findAll(".therapeutic-history-block > h4").map((heading) => heading.text())).toEqual([
+      "Анамнез болезни", "Анамнез жизни", "Осмотр", "Рекомендации", "Назначения",
     ]);
-    expect(section.findAll('[role="tablist"]')).toHaveLength(1);
-    expect(panels).toHaveLength(5);
-    expect(tabs[0]!.attributes("aria-selected")).toBe("true");
-    expect(panels[0]!.attributes("hidden")).toBeUndefined();
-    expect(panels.slice(1).every((panel) => panel.attributes("hidden") !== undefined)).toBe(true);
-    expect(panels[0]!.text()).toContain("Проблема 1: Не ест");
-    expect(panels[0]!.text()).toContain("Вчера");
-    expect(panels[0]!.text()).toContain("Название препарата");
-    expect(panels[0]!.text()).toContain("Мелоксикам");
-
-    await tabs[0]!.trigger("keydown", { key: "ArrowRight" });
-    expect(tabs[1]!.attributes("aria-selected")).toBe("true");
-    expect(panels[0]!.attributes("hidden")).toBeDefined();
-    expect(panels[1]!.attributes("hidden")).toBeUndefined();
-    expect(panels[1]!.text()).toContain("Содержится в квартире");
-
-    await tabs[1]!.trigger("keydown", { key: "End" });
-    expect(tabs[4]!.attributes("aria-selected")).toBe("true");
-    expect(panels[4]!.text()).toContain("Диетический корм");
-    await tabs[3]!.trigger("click");
-    expect(tabs[3]!.attributes("aria-selected")).toBe("true");
-    expect(panels[3]!.text()).toContain("Контроль через неделю");
+    expect(section.text()).toContain("Проблема 1: Не ест");
+    expect(section.text()).toContain("Проблема 2: Вялость");
+    expect(section.text()).toContain("Мелоксикам");
+    expect(section.text()).toContain("Содержится в квартире");
+    expect(section.text()).toContain("Контроль через неделю");
+    expect(section.text()).toContain("Диетический корм");
+    expect(section.get(".therapeutic-history-text").text()).toBe("Снижение аппетита\nсо вчерашнего дня");
   });
 
-  it.each([
-    { field: "recommendations", text: "Только рекомендации", selectedTab: "Рекомендации" },
-    { field: "prescriptions", text: "Только назначения", selectedTab: "Назначения" },
-  ] as const)("opens the first populated therapeutic tab for a sparse $field record", ({ field, text, selectedTab }) => {
-    const value = {
-      diseaseAnamnesis: { text: "", problems: [], selectedIds: [] },
-      lifeAnamnesis: { text: "", selectedIds: [], currentMedications: "", allergies: "" },
-      examination: { text: "", selectedIds: [] },
-      recommendations: "",
-      prescriptions: "",
-      [field]: text,
-    };
+  it("omits empty therapeutic history blocks", () => {
     const wrapper = mount(MedicalRecordEntry, {
       props: {
         record: {
@@ -591,7 +563,13 @@ describe("MedicalRecordEntry", () => {
             "therapeutic-appointment": {
               kind: "therapeutic-appointment",
               templateVersion: "therapeutic-appointment-v1",
-              value,
+              value: {
+                diseaseAnamnesis: { text: "", problems: [], selectedIds: [] },
+                lifeAnamnesis: { text: "", selectedIds: [], currentMedications: "", allergies: "" },
+                examination: { text: "", selectedIds: [] },
+                recommendations: "Только рекомендации",
+                prescriptions: "",
+              },
               authorAccountId: "doctor-1",
               authorDisplayName: "Вера Врач",
               updatedAt: "2026-07-21T12:00:00.000Z",
@@ -606,8 +584,7 @@ describe("MedicalRecordEntry", () => {
 
     const section = wrapper.findAll(".encounter-history-section")
       .find((candidate) => candidate.get("h3").text() === "Терапевтический приём")!;
-    const selected = section.get<HTMLButtonElement>('[role="tab"][aria-selected="true"]');
-    expect(selected.text()).toBe(selectedTab);
-    expect(section.get('[role="tabpanel"]:not([hidden])').text()).toContain(text);
+    expect(section.findAll(".therapeutic-history-block > h4").map((heading) => heading.text())).toEqual(["Рекомендации"]);
+    expect(section.text()).toContain("Только рекомендации");
   });
 });


### PR DESCRIPTION
### Motivation

- Упростить чтение сохранённых терапевтических приёмов: все заполненные разделы должны быть видны одновременно и представлены компактным текстовым форматом без интерактивных вкладок.
- Сохранить иерархию данных (раздел → проблема → параметры), при этом не отображать пустые блоки и сохранить многострочный текст.

### Description

- Заменён табовый read-only интерфейс в `src/components/TherapeuticAppointmentView.vue` на последовательные семантические секции (`section`, `dl/dt/dd`), удалена логика активной вкладки и клавиатурной навигации. 
- Показываются только непустые блоки: вычисляемые `populatedProblems`, `hasDisease`, `hasLife` и `hasExamination` фильтруют пустые данные перед рендером. 
- Параметры проблемы и выборы отображаются как пары «подпись — значение» через `problemDetails` и `therapeuticSelectionDetails`, при этом переносы строк и многострочные комментарии сохраняются. 
- Обновлены стили в `src/styles.css` для компактного, безрамочного текстового представления и упрощены правила для блоков проблем/значений. 
- Добавлены/изменены тесты в `tests/medicalRecordEntry.spec.ts`, которые проверяют: отображение всех заполненных разделов одновременно, порядок и содержимое нескольких проблем, сохранение переносов и пропуск пустых блоков.

### Testing

- Выполнены компонентные тесты: `npx vitest run tests/medicalRecordEntry.spec.ts` — успешно, все тесты прошли. 
- Статический анализ: `npm run lint:check` — успешно. 
- Сборка UI: `npm run build:ui` — успешно. 
- Покрытие: `npm run coverage -- --run tests/medicalRecordEntry.spec.ts` — запущено, целевой компонент `TherapeuticAppointmentView.vue` покрыт полностью по линиям в рамках теста; общий репозиторный отчёт покрытий не изменялся целиком. 
- E2E compose-suite: `npm run test:e2e:compose` — не выполнен в CI среде из‑за отсутствия Docker. 
- Визуальная проверка через Playwright не завершилась из‑за невозможности загрузить браузеры (`npx playwright install chromium` вернул 403 при загрузке).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8eaa58f8f48321bd7562ba4eeafe4b)