### PR TITLE
feat: add abdominal X-ray study

### DIFF
--- a/api-node/package.json
+++ b/api-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klinok/api-node",
-  "version": "0.14.3",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "main": "./dist/server.js",

--- a/api-node/test/commands.spec.ts
+++ b/api-node/test/commands.spec.ts
@@ -668,6 +668,35 @@ describe("command boundary", () => {
       mode: "tree",
       findings: [{ findingName: "Заключение", value: "Без патологии" }],
     }] });
+    const abdominalXray = validateMedicalEncounter({
+      ...base,
+      sections: {
+        ...base.sections,
+        "instrumental-tests": { studies: [{
+          id: "223e4567-e89b-12d3-a456-426614174000",
+          date: "2026-08-10",
+          typeId: "instrumental.study.xray-abdomen",
+          typeName: "forged",
+          mode: "tree",
+          findings: [{
+            findingId: "instrumental.finding.xray-abdomen.26",
+            findingName: "forged",
+            value: "  Без рентгенологических признаков патологии  ",
+            children: [],
+          }],
+        }] },
+      },
+    });
+    expect(abdominalXray.sections["instrumental-tests"]).toMatchObject({ studies: [{
+      typeId: "instrumental.study.xray-abdomen",
+      typeName: "Рентгенография брюшной полости",
+      mode: "tree",
+      findings: [{
+        findingId: "instrumental.finding.xray-abdomen.26",
+        findingName: "Заключение",
+        value: "Без рентгенологических признаков патологии",
+      }],
+    }] });
     expect(() => validateMedicalEncounter({
       ...base,
       sections: { ...base.sections, "instrumental-tests": { studies: [] } },

--- a/e2e/operational.spec.ts
+++ b/e2e/operational.spec.ts
@@ -1021,6 +1021,165 @@ test("fresh provisioning, Doctor approval, grant, draft, and confirmation", asyn
   const xrayConclusion = xrayStudy.getByLabel("Заключение", { exact: true });
   await xrayConclusion.fill("Очаговых и диффузных изменений в лёгочных полях не выявлено");
 
+  await instrumentalType.fill("Рентгенография брюшной полости");
+  await instrumentalCard.getByRole("option", { name: "Рентгенография брюшной полости", exact: true }).click();
+  await addInstrumentalStudy.click();
+  const abdominalXrayStudy = instrumentalCard.locator(".instrumental-study-card").filter({
+    has: doctorPage.getByRole("heading", { name: "Рентгенография брюшной полости", exact: true }),
+  });
+  const deleteAbdominalXrayStudy = abdominalXrayStudy.getByRole("button", { name: "Удалить исследование" });
+  const addAbdominalXrayFinding = async (findingName: string) => {
+    const combobox = abdominalXrayStudy.getByRole("combobox", { name: "Добавить раздел исследования", exact: true });
+    await combobox.fill(findingName);
+    await abdominalXrayStudy.getByRole("option", { name: findingName, exact: true }).click();
+    const add = combobox.locator("xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' instrumental-finding-create ')][1]")
+      .getByRole("button", { name: "Добавить раздел" });
+    await add.click();
+    return add;
+  };
+  const addAbdominalXrayIndicator = async (parentName: string, findingName: string) => {
+    const combobox = abdominalXrayStudy.getByRole("combobox", {
+      name: `Добавить показатель для «${parentName}»`,
+      exact: true,
+    });
+    await combobox.fill(findingName);
+    await abdominalXrayStudy.getByRole("option", { name: findingName, exact: true }).click();
+    const add = combobox.locator("xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' instrumental-finding-create ')][1]")
+      .getByRole("button", { name: "Добавить показатель", exact: true });
+    await add.click();
+    return add;
+  };
+
+  const addAbdominalProjections = await addAbdominalXrayFinding("Выполненные проекции");
+  const abdominalProjections = abdominalXrayStudy.getByRole("group", { name: "Проекции", exact: true });
+  await abdominalProjections.getByRole("checkbox", { name: "Левая латеролатеральная", exact: true }).check();
+  await abdominalProjections.getByRole("checkbox", { name: "Правая латеролатеральная", exact: true }).check();
+  await abdominalProjections.getByRole("checkbox", { name: "Вентродорсальная", exact: true }).check();
+
+  const addAbdominalSkeleton = await addAbdominalXrayFinding("Костно-суставной аппарат");
+  await abdominalXrayStudy.getByRole("combobox", {
+    name: "Значение показателя «Костно-суставной аппарат»",
+    exact: true,
+  }).selectOption({ label: "Имеет признаки патологий" });
+  const abdominalPathologies = abdominalXrayStudy.getByRole("group", { name: "Признаки патологий", exact: true });
+  await abdominalPathologies.getByRole("checkbox", { name: "Остеофиты", exact: true }).check();
+  await abdominalPathologies.getByRole("checkbox", { name: "Перелом", exact: true }).check();
+  await abdominalXrayStudy.getByLabel("Описание перелома", { exact: true }).fill("Перелом таза");
+
+  const addAbdominalDiaphragm = await addAbdominalXrayFinding("Купол диафрагмы");
+  const addAbdominalDiaphragmCharacteristics = await addAbdominalXrayIndicator(
+    "Купол диафрагмы",
+    "Характеристики купола",
+  );
+  const abdominalDiaphragm = abdominalXrayStudy.locator(
+    '[data-finding-id="instrumental.finding.xray-abdomen.9.0"]',
+  );
+  const abdominalDiaphragmRegularity = abdominalDiaphragm.getByRole("combobox", {
+    name: "Ровность купола", exact: true,
+  });
+  const abdominalDiaphragmDefinition = abdominalDiaphragm.getByRole("combobox", {
+    name: "Чёткость купола", exact: true,
+  });
+  const abdominalDiaphragmProjection = abdominalDiaphragm.getByRole("combobox", {
+    name: "Проекция измерения", exact: true,
+  });
+  await abdominalDiaphragmRegularity.selectOption({ label: "Ровный" });
+  await abdominalDiaphragmDefinition.selectOption({ label: "Чёткий" });
+  await abdominalDiaphragmProjection.selectOption({ label: "На LL-проекции в области межреберья" });
+  await abdominalDiaphragm.getByLabel("Межреберье на LL-проекции", { exact: true }).fill("8");
+  await abdominalDiaphragmRegularity.selectOption({ label: "Неровный" });
+  await expect(abdominalDiaphragmDefinition).toHaveValue("instrumental.finding.xray-abdomen.9.0.3");
+  await expect(abdominalDiaphragmProjection).toHaveValue("instrumental.finding.xray-abdomen.9.0.5");
+
+  const addAbdominalWall = await addAbdominalXrayFinding("Брюшная стенка");
+  const addAbdominalWallCharacteristics = await addAbdominalXrayIndicator(
+    "Брюшная стенка",
+    "Характеристики брюшной стенки",
+  );
+  const abdominalWall = abdominalXrayStudy.locator(
+    '[data-finding-id="instrumental.finding.xray-abdomen.11.0"]',
+  );
+  await abdominalWall.getByRole("combobox", { name: "Ровность стенки", exact: true })
+    .selectOption({ label: "Ровная" });
+  await abdominalWall.getByRole("combobox", { name: "Чёткость стенки", exact: true })
+    .selectOption({ label: "Нечёткая" });
+
+  const addAbdominalLiver = await addAbdominalXrayFinding("Печень");
+  const addAbdominalLiverBorders = await addAbdominalXrayIndicator("Печень", "Границы");
+  const abdominalLiverBorders = abdominalXrayStudy.locator(
+    '[data-finding-id="instrumental.finding.xray-abdomen.12.3"]',
+  );
+  await abdominalLiverBorders.getByRole("combobox", { name: "Чёткость границ", exact: true })
+    .selectOption({ label: "Чёткие" });
+  await abdominalLiverBorders.getByRole("combobox", {
+    name: "Положение относительно рёберной дуги", exact: true,
+  }).selectOption({ label: "Вровень с рёберной дугой" });
+
+  const addAbdominalSpleen = await addAbdominalXrayFinding("Селезёнка");
+  const addAbdominalSpleenShadow = await addAbdominalXrayIndicator("Селезёнка", "Тень");
+  const abdominalSpleenShadow = abdominalXrayStudy.locator(
+    '[data-finding-id="instrumental.finding.xray-abdomen.13.1"]',
+  );
+  await abdominalSpleenShadow.getByRole("combobox", { name: "Размер тени", exact: true })
+    .selectOption({ label: "Не увеличена" });
+  await abdominalSpleenShadow.getByRole("combobox", { name: "Однородность тени", exact: true })
+    .selectOption({ label: "Однородная" });
+
+  const addSmallIntestine = await addAbdominalXrayFinding("Тонкий отдел кишечника");
+  const addSmallIntestineContents = await addAbdominalXrayIndicator("Тонкий отдел кишечника", "Содержимое");
+  const smallIntestineContents = abdominalXrayStudy.locator(
+    '[data-finding-id="instrumental.finding.xray-abdomen.21.3"]',
+  );
+  await smallIntestineContents.getByRole("combobox", { name: "Значение показателя «Содержимое»", exact: true })
+    .selectOption({ label: "Визуализируется" });
+  const smallIntestineContentsPanel = abdominalXrayStudy.getByRole("group", {
+    name: "Содержимое тонкого кишечника", exact: true,
+  });
+  await smallIntestineContentsPanel.getByRole("checkbox", { name: "Жидкость", exact: true }).check();
+  await smallIntestineContentsPanel.getByRole("checkbox", { name: "Газ", exact: true }).check();
+
+  const addLargeIntestine = await addAbdominalXrayFinding("Толстый отдел кишечника");
+  const addLargeIntestineContents = await addAbdominalXrayIndicator("Толстый отдел кишечника", "Содержимое");
+  const largeIntestineContents = abdominalXrayStudy.locator(
+    '[data-finding-id="instrumental.finding.xray-abdomen.22.3"]',
+  );
+  await largeIntestineContents.getByRole("combobox", { name: "Значение показателя «Содержимое»", exact: true })
+    .selectOption({ label: "Визуализируется" });
+  const largeIntestineContentsPanel = abdominalXrayStudy.getByRole("group", {
+    name: "Содержимое толстого кишечника", exact: true,
+  });
+  await largeIntestineContentsPanel.getByRole("checkbox", { name: "Жидкость", exact: true }).check();
+  await largeIntestineContentsPanel.getByRole("checkbox", { name: "Газ", exact: true }).check();
+  await largeIntestineContentsPanel.getByRole("checkbox", { name: "Каловые массы", exact: true }).check();
+
+  const addReproductiveSystem = await addAbdominalXrayFinding("Репродуктивная система");
+  const addPenis = await addAbdominalXrayIndicator("Репродуктивная система", "Половой член");
+  const addOsPenis = await addAbdominalXrayIndicator("Половой член", "Os penis");
+  const osPenis = abdominalXrayStudy.locator('[data-finding-id="instrumental.finding.xray-abdomen.23.3.1"]');
+  const osPenisVisibility = osPenis.getByRole("combobox", { name: "Значение показателя «Os penis»", exact: true });
+  await osPenisVisibility.selectOption({ label: "Визуализируется" });
+  let osPenisCharacteristics = abdominalXrayStudy.locator(
+    '[data-finding-id="instrumental.finding.xray-abdomen.23.3.1.2.characteristics"]',
+  );
+  await osPenisCharacteristics.getByRole("combobox", { name: "Чёткость", exact: true })
+    .selectOption({ label: "Чётко" });
+  await osPenisCharacteristics.getByRole("checkbox", { name: "Имеет перелом", exact: true }).check();
+  await expect(osPenisCharacteristics.locator(":scope > .instrumental-finding-content"))
+    .toHaveAttribute("data-hierarchy-depth", "3");
+  await osPenisVisibility.selectOption({ label: "Не визуализируется" });
+  await expect(osPenisCharacteristics).toHaveCount(0);
+  await osPenisVisibility.selectOption({ label: "Визуализируется" });
+  osPenisCharacteristics = abdominalXrayStudy.locator(
+    '[data-finding-id="instrumental.finding.xray-abdomen.23.3.1.2.characteristics"]',
+  );
+  await osPenisCharacteristics.getByRole("combobox", { name: "Чёткость", exact: true })
+    .selectOption({ label: "Нечётко" });
+  await osPenisCharacteristics.getByRole("checkbox", { name: "Имеет перелом", exact: true }).check();
+
+  const addAbdominalConclusion = await addAbdominalXrayFinding("Заключение");
+  const abdominalConclusion = abdominalXrayStudy.getByLabel("Заключение", { exact: true });
+  await abdominalConclusion.fill("Признаки кишечной непроходимости");
+
   await addSectionSelect.selectOption("recommendations");
   const recommendationsCard = doctorPage.locator(".encounter-section-card").filter({
     has: doctorPage.getByRole("heading", { name: "Рекомендации", exact: true, level: 3 }),
@@ -1086,6 +1245,25 @@ test("fresh provisioning, Doctor approval, grant, draft, and confirmation", asyn
     addXrayLungs,
     addXrayConclusion,
     deleteXrayStudy,
+    addAbdominalProjections,
+    addAbdominalSkeleton,
+    addAbdominalDiaphragm,
+    addAbdominalDiaphragmCharacteristics,
+    addAbdominalWall,
+    addAbdominalWallCharacteristics,
+    addAbdominalLiver,
+    addAbdominalLiverBorders,
+    addAbdominalSpleen,
+    addAbdominalSpleenShadow,
+    addSmallIntestine,
+    addSmallIntestineContents,
+    addLargeIntestine,
+    addLargeIntestineContents,
+    addReproductiveSystem,
+    addPenis,
+    addOsPenis,
+    addAbdominalConclusion,
+    deleteAbdominalXrayStudy,
     deleteSediment,
     deleteConcrementSize,
     therapeuticCard.getByRole("button", { name: "Удалить раздел", exact: true }),
@@ -1267,6 +1445,10 @@ test("fresh provisioning, Doctor approval, grant, draft, and confirmation", asyn
   await expect(doctorRecord).toContainText("Рентгенография грудной полости");
   await expect(doctorRecord).toContainText("Межреберье на LL-проекции: 7");
   await expect(doctorRecord).toContainText("Очаговых и диффузных изменений в лёгочных полях не выявлено");
+  await expect(doctorRecord).toContainText("Рентгенография брюшной полости");
+  await expect(doctorRecord).toContainText("Межреберье на LL-проекции: 8");
+  await expect(doctorRecord).toContainText("Перелом таза");
+  await expect(doctorRecord).toContainText("Признаки кишечной непроходимости");
   await doctorRecord.getByRole("button", { name: "Редактировать запись" }).click();
   const inlineEditor = doctorRecord.locator(".encounter-editor-inline");
   await expect(inlineEditor.getByLabel("Взятие анализов", { exact: true })).toBeChecked();
@@ -1297,6 +1479,25 @@ test("fresh provisioning, Doctor approval, grant, draft, and confirmation", asyn
   await expect(inlineXrayStudy.getByLabel("Межреберье на LL-проекции", { exact: true })).toHaveValue("7");
   await expect(inlineXrayStudy.getByLabel("Заключение", { exact: true }))
     .toHaveValue("Очаговых и диффузных изменений в лёгочных полях не выявлено");
+  const inlineAbdominalXrayStudy = inlineEditor.locator(".instrumental-study-card").filter({
+    has: doctorPage.getByRole("heading", { name: "Рентгенография брюшной полости", exact: true }),
+  });
+  await expect(inlineAbdominalXrayStudy.getByRole("checkbox", { name: "Левая латеролатеральная", exact: true }))
+    .toBeChecked();
+  await expect(inlineAbdominalXrayStudy.getByRole("checkbox", { name: "Правая латеролатеральная", exact: true }))
+    .toBeChecked();
+  await expect(inlineAbdominalXrayStudy.getByRole("checkbox", { name: "Вентродорсальная", exact: true }))
+    .toBeChecked();
+  await expect(inlineAbdominalXrayStudy.getByRole("combobox", { name: "Ровность купола", exact: true }))
+    .toHaveValue("instrumental.finding.xray-abdomen.9.0.2");
+  await expect(inlineAbdominalXrayStudy.getByRole("combobox", { name: "Чёткость купола", exact: true }))
+    .toHaveValue("instrumental.finding.xray-abdomen.9.0.3");
+  await expect(inlineAbdominalXrayStudy.getByLabel("Межреберье на LL-проекции", { exact: true })).toHaveValue("8");
+  await expect(inlineAbdominalXrayStudy.getByRole("combobox", { name: "Чёткость", exact: true }))
+    .toHaveValue("instrumental.finding.xray-abdomen.23.3.1.4");
+  await expect(inlineAbdominalXrayStudy.getByRole("checkbox", { name: "Имеет перелом", exact: true })).toBeChecked();
+  await expect(inlineAbdominalXrayStudy.getByLabel("Заключение", { exact: true }))
+    .toHaveValue("Признаки кишечной непроходимости");
   await editCancel.click();
   await expect(inlineEditor).toHaveCount(0);
   await doctorPage.context().setOffline(false);
@@ -1310,6 +1511,8 @@ test("fresh provisioning, Doctor approval, grant, draft, and confirmation", asyn
   await ownerHistorySearch.fill("Проведение исследования");
   await expect(ownerRecord).toBeVisible({ timeout: replicationTimeout });
   await ownerHistorySearch.fill("диффузных изменений");
+  await expect(ownerRecord).toBeVisible({ timeout: replicationTimeout });
+  await ownerHistorySearch.fill("кишечной непроходимости");
   await expect(ownerRecord).toBeVisible({ timeout: replicationTimeout });
   await ownerHistorySearch.fill("");
   const laboratoryComparison = ownerPage.locator(".laboratory-comparison");
@@ -1454,6 +1657,21 @@ test("fresh provisioning, Doctor approval, grant, draft, and confirmation", asyn
     .filter({ hasText: "Рентгенография грудной полости" });
   await expect(ownerXrayStudy.getByText("Межреберье на LL-проекции: 7", { exact: true })).toBeVisible();
   await expect(ownerXrayStudy.getByText("Заключение: Очаговых и диффузных изменений в лёгочных полях не выявлено", { exact: true })).toBeVisible();
+  const ownerAbdominalXrayStudy = ownerInstrumental.locator(".instrumental-history-study")
+    .filter({ hasText: "Рентгенография брюшной полости" });
+  await expect(ownerAbdominalXrayStudy.getByText("Левая латеролатеральная", { exact: true })).toBeVisible();
+  await expect(ownerAbdominalXrayStudy.getByText("Правая латеролатеральная", { exact: true })).toBeVisible();
+  await expect(ownerAbdominalXrayStudy.getByText("Вентродорсальная", { exact: true })).toBeVisible();
+  await expect(ownerAbdominalXrayStudy.getByText("Описание перелома: Перелом таза", { exact: true })).toBeVisible();
+  await expect(ownerAbdominalXrayStudy.getByText("Межреберье на LL-проекции: 8", { exact: true })).toBeVisible();
+  await expect(ownerAbdominalXrayStudy.getByText("Жидкость", { exact: true })).toHaveCount(2);
+  await expect(ownerAbdominalXrayStudy.getByText("Газ", { exact: true })).toHaveCount(2);
+  await expect(ownerAbdominalXrayStudy.getByText("Нечётко", { exact: true })).toBeVisible();
+  await expect(ownerAbdominalXrayStudy.getByText("Имеет перелом", { exact: true })).toBeVisible();
+  await expect(ownerAbdominalXrayStudy.getByText(
+    "Заключение: Признаки кишечной непроходимости",
+    { exact: true },
+  )).toBeVisible();
   await expect(ownerRecord.locator("summary")).not.toContainText("Диагноз:");
   const ownerDiagnosis = ownerRecord.locator(".encounter-history-section").filter({
     has: ownerPage.getByRole("heading", { name: "Диагноз", exact: true }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "klinok",
-  "version": "0.14.3",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "klinok",
-      "version": "0.14.3",
+      "version": "0.15.0",
       "workspaces": [
         "api-node",
         "packages/contracts"
@@ -39,7 +39,7 @@
     },
     "api-node": {
       "name": "@klinok/api-node",
-      "version": "0.14.3",
+      "version": "0.15.0",
       "dependencies": {
         "@fastify/cookie": "^11.0.2",
         "@fastify/rate-limit": "^11.1.0",
@@ -3116,9 +3116,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.12.1.tgz",
-      "integrity": "sha512-FWi+tQvwxR/PeRX7Z2mhfEF5ozJ3jn9asiiclzKXNSzJRHAYcU924aIOKAdHFJ+YIKieh3cqr1IwCOvTr41B3Q==",
+      "version": "5.12.3",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.12.3.tgz",
+      "integrity": "sha512-reZ8wce5VNCcufIt9AVtzZa3L4u1j8esikn7OEgHWLVpRpL5R7Y2+Xzj70OUkv5zDfzUAxXZT6cu4Rt0zr3EKA==",
       "funding": [
         {
           "type": "github",
@@ -5531,7 +5531,7 @@
     },
     "packages/contracts": {
       "name": "@klinok/contracts",
-      "version": "0.14.3"
+      "version": "0.15.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "klinok",
   "private": true,
-  "version": "0.14.3",
+  "version": "0.15.0",
   "type": "module",
   "workspaces": [
     "api-node",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klinok/contracts",
-  "version": "0.14.3",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/contracts/src/instrumental.ts
+++ b/packages/contracts/src/instrumental.ts
@@ -2,6 +2,7 @@
 // All rights reserved.
 // This file is a part of Klinok application
 
+import { XRAY_ABDOMEN_FINDINGS } from "./xrayAbdomen.js";
 import { XRAY_THORAX_FINDINGS } from "./xrayThorax.js";
 
 export type InstrumentalStudyMode = "tree" | "narrative";
@@ -302,6 +303,7 @@ const ultrasoundAbdomen: readonly InstrumentalFindingCatalogItem[] = [
 export const INSTRUMENTAL_STUDY_CATALOG: readonly InstrumentalStudyTypeCatalogItem[] = [
   { id: "instrumental.study.ultrasound-abdomen", name: "УЗИ органов брюшной полости", mode: "tree", findings: ultrasoundAbdomen },
   { id: "instrumental.study.xray-thorax", name: "Рентгенография грудной полости", mode: "tree", findings: XRAY_THORAX_FINDINGS },
+  { id: "instrumental.study.xray-abdomen", name: "Рентгенография брюшной полости", mode: "tree", findings: XRAY_ABDOMEN_FINDINGS },
 ];
 
 export const INSTRUMENTAL_STUDY_OPTIONS = INSTRUMENTAL_STUDY_CATALOG.map(({ id, name }) => ({ id, label: name }));

--- a/packages/contracts/src/xrayAbdomen.ts
+++ b/packages/contracts/src/xrayAbdomen.ts
@@ -1,0 +1,400 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of Klinok application
+
+import type {
+  InstrumentalFindingCatalogItem,
+  InstrumentalFindingKind,
+  InstrumentalSelectionSet,
+} from "./instrumental.js";
+
+const prefix = "instrumental.finding.xray-abdomen";
+const id = (code: string) => `${prefix}.${code}`;
+const node = (
+  code: string,
+  name: string,
+  kind: InstrumentalFindingKind,
+  children: readonly InstrumentalFindingCatalogItem[] = [],
+): InstrumentalFindingCatalogItem => ({ id: id(code), name, kind, children });
+const group = (code: string, name: string, children: readonly InstrumentalFindingCatalogItem[]) =>
+  node(code, name, "group", children);
+const choice = (code: string, name: string, children: readonly InstrumentalFindingCatalogItem[] = []) =>
+  node(code, name, "choice", children);
+const shortText = (code: string, name: string) => node(code, name, "short-text");
+const longText = (code: string, name: string) => node(code, name, "long-text");
+const requiredShortText = (code: string, name: string): InstrumentalFindingCatalogItem => ({
+  ...shortText(code, name),
+  required: true,
+});
+const requiredLongText = (code: string, name: string): InstrumentalFindingCatalogItem => ({
+  ...longText(code, name),
+  required: true,
+});
+const multipleGroup = (
+  code: string,
+  name: string,
+  children: readonly InstrumentalFindingCatalogItem[],
+): InstrumentalFindingCatalogItem => ({
+  ...group(code, name, children),
+  selectionMode: "multiple",
+});
+const selectionSetGroup = (
+  code: string,
+  name: string,
+  children: readonly InstrumentalFindingCatalogItem[],
+  selectionSets: readonly InstrumentalSelectionSet[],
+): InstrumentalFindingCatalogItem => ({
+  ...group(code, name, children),
+  selectionSets,
+});
+const inlineSelectionSetGroup = (
+  code: string,
+  name: string,
+  children: readonly InstrumentalFindingCatalogItem[],
+  selectionSets: readonly InstrumentalSelectionSet[],
+): InstrumentalFindingCatalogItem => ({
+  ...selectionSetGroup(code, name, children, selectionSets),
+  selectionMode: "multiple",
+});
+
+export const XRAY_ABDOMEN_FINDINGS: readonly InstrumentalFindingCatalogItem[] = [
+  group("1", "Выполненные проекции", [
+    multipleGroup("1.0", "Проекции", [
+      choice("1.0.1", "Левая латеролатеральная"),
+      choice("1.0.2", "Правая латеролатеральная"),
+      choice("1.0.3", "Вентродорсальная"),
+      choice("1.0.4", "Дорсовентральная"),
+    ]),
+  ]),
+  group("2", "Качество рентгенограмм", [
+    choice("2.0.1", "Высокое"), choice("2.0.2", "Среднее"), choice("2.0.3", "Низкое"),
+  ]),
+  group("3", "Режим экспозиции", [
+    choice("3.0.1", "Удовлетворительный"),
+    choice("3.0.2", "Недостаточный (засветка)"),
+    choice("3.0.3", "Избыточный (затемнено)"),
+  ]),
+  shortText("4", "Область интересов"),
+  group("5", "Охват области интересов", [choice("5.0.1", "Полный"), choice("5.0.2", "Неполный")]),
+  group("6", "Мягкие ткани", [
+    choice("6.0.1", "Не изменены"),
+    choice("6.0.2", "Имеют изменения", [
+      choice("6.0.2.1", "Мягкотканные образования"),
+      choice("6.0.2.2", "Подкожная эмфизема"),
+      choice("6.0.2.3", "Инородное тело", [
+        choice("6.0.2.3.1", "Капсула чипа"),
+        choice("6.0.2.3.2", "Пуля"),
+        choice("6.0.2.3.3", "Другое", [requiredLongText("6.0.2.3.3.text", "Описание инородного тела")]),
+      ]),
+      choice("6.0.2.4", "Другое", [requiredLongText("6.0.2.4.text", "Описание изменений")]),
+    ]),
+  ]),
+  group("7", "Упитанность", [
+    choice("7.0.1", "Средняя"), choice("7.0.2", "Снижена"), choice("7.0.3", "Повышена"),
+  ]),
+  group("8", "Костно-суставной аппарат", [
+    choice("8.0.1", "Соответствует породе и возрасту"),
+    choice("8.0.2", "Патологий не имеет"),
+    choice("8.0.3", "Имеет признаки патологий", [
+      multipleGroup("8.0.3.findings", "Признаки патологий", [
+        choice("8.0.3.1", "Остеофиты"),
+        choice("8.0.3.2", "Перелом", [requiredLongText("8.0.3.2.text", "Описание перелома")]),
+        choice("8.0.3.3", "Деформации тел грудных позвонков"),
+        choice("8.0.3.4", "Деформация тел поясничных позвонков"),
+        choice("8.0.3.5", "Другое", [requiredLongText("8.0.3.5.text", "Описание патологии")]),
+      ]),
+    ]),
+  ]),
+  group("9", "Купол диафрагмы", [
+    selectionSetGroup("9.0", "Характеристики купола", [
+      choice("9.0.1", "Ровный"), choice("9.0.2", "Неровный"),
+      choice("9.0.3", "Чёткий"), choice("9.0.4", "Нечёткий"),
+      choice("9.0.5", "На LL-проекции в области межреберья", [
+        requiredShortText("9.0.5.intercostal", "Межреберье на LL-проекции"),
+      ]),
+      choice("9.0.6", "На VD-проекции в области межреберья", [
+        requiredShortText("9.0.6.intercostal", "Межреберье на VD-проекции"),
+      ]),
+    ], [{
+      key: "regularity",
+      name: "Ровность купола",
+      choiceIds: [id("9.0.1"), id("9.0.2")],
+    }, {
+      key: "definition",
+      name: "Чёткость купола",
+      choiceIds: [id("9.0.3"), id("9.0.4")],
+    }, {
+      key: "projection",
+      name: "Проекция измерения",
+      choiceIds: [id("9.0.5"), id("9.0.6")],
+    }]),
+    group("9.1", "Ножки диафрагмы", [
+      choice("9.1.1", "Визуализируются", [
+        requiredShortText("9.1.1.vertebra", "Уровень грудного позвонка"),
+      ]),
+      choice("9.1.2", "Не визуализируются"),
+    ]),
+  ]),
+  group("10", "Серозная дифференциация", [
+    choice("10.0.1", "Сохранена"), choice("10.0.2", "Отсутствует"),
+  ]),
+  group("11", "Брюшная стенка", [
+    selectionSetGroup("11.0", "Характеристики брюшной стенки", [
+      choice("11.0.1", "Ровная"), choice("11.0.2", "Неровная"),
+      choice("11.0.3", "Чёткая"), choice("11.0.4", "Нечёткая"),
+    ], [{
+      key: "regularity",
+      name: "Ровность стенки",
+      choiceIds: [id("11.0.1"), id("11.0.2")],
+    }, {
+      key: "definition",
+      name: "Чёткость стенки",
+      choiceIds: [id("11.0.3"), id("11.0.4")],
+    }]),
+    group("11.1", "Патологии", [
+      choice("11.1.1", "Не выявлены"),
+      choice("11.1.2", "Выявлены", [requiredLongText("11.1.2.text", "Описание патологий")]),
+    ]),
+  ]),
+  group("12", "Печень", [
+    group("12.1", "Тень", [choice("12.1.1", "Однородная"), choice("12.1.2", "Неоднородная")]),
+    group("12.2", "Плотность", [
+      choice("12.2.1", "Средняя"), choice("12.2.2", "Высокая"), choice("12.2.3", "Низкая"),
+    ]),
+    selectionSetGroup("12.3", "Границы", [
+      choice("12.3.1", "Чёткие"), choice("12.3.2", "Нечёткие"),
+      choice("12.3.3", "Не доходят до границ рёберной дуги"),
+      choice("12.3.4", "Вровень с рёберной дугой"),
+      choice("12.3.5", "Незначительно выходят за рёберную дугу"),
+      choice("12.3.6", "Значительно выходят за рёберную дугу"),
+    ], [{
+      key: "definition",
+      name: "Чёткость границ",
+      choiceIds: [id("12.3.1"), id("12.3.2")],
+    }, {
+      key: "rib-arch-position",
+      name: "Положение относительно рёберной дуги",
+      choiceIds: [id("12.3.3"), id("12.3.4"), id("12.3.5"), id("12.3.6")],
+    }]),
+    group("12.4", "Патологии", [
+      choice("12.4.1", "Не выявлены"),
+      choice("12.4.2", "Выявлены", [requiredLongText("12.4.2.text", "Описание патологий")]),
+    ]),
+  ]),
+  group("13", "Селезёнка", [
+    selectionSetGroup("13.1", "Тень", [
+      choice("13.1.1", "Увеличена"), choice("13.1.2", "Не увеличена"),
+      choice("13.1.3", "Однородная"), choice("13.1.4", "Неоднородная"),
+    ], [{
+      key: "size",
+      name: "Размер тени",
+      choiceIds: [id("13.1.1"), id("13.1.2")],
+    }, {
+      key: "homogeneity",
+      name: "Однородность тени",
+      choiceIds: [id("13.1.3"), id("13.1.4")],
+    }]),
+    group("13.2", "Плотность", [
+      choice("13.2.1", "Средняя"), choice("13.2.2", "Высокая"), choice("13.2.3", "Низкая"),
+    ]),
+    group("13.3", "Положение", [choice("13.3.1", "Правильное"), choice("13.3.2", "Неправильное")]),
+    group("13.4", "Границы", [choice("13.4.1", "Чёткие"), choice("13.4.2", "Нечёткие")]),
+    group("13.5", "Патологии", [
+      choice("13.5.1", "Не выявлены"),
+      choice("13.5.2", "Выявлены", [requiredLongText("13.5.2.text", "Описание патологий")]),
+    ]),
+  ]),
+  group("14", "Область поджелудочной железы", [
+    group("14.1", "Патологии", [
+      choice("14.1.1", "Не выявлены"),
+      choice("14.1.2", "Выявлены", [requiredLongText("14.1.2.text", "Описание патологий")]),
+    ]),
+  ]),
+  group("15", "Почки", [
+    group("15.1", "Положение", [
+      choice("15.1.1", "Правильное"),
+      choice("15.1.2", "Атипичное", [requiredLongText("15.1.2.text", "Описание положения")]),
+    ]),
+    group("15.2", "Форма", [
+      choice("15.2.1", "Правильная"), choice("15.2.2", "Неправильная"),
+      choice("15.2.3", "Бобовидная"), choice("15.2.4", "Округлая"),
+    ]),
+    group("15.3", "Границы", [choice("15.3.1", "Чёткие"), choice("15.3.2", "Нечёткие")]),
+    group("15.4", "Плотность", [
+      choice("15.4.1", "Средняя"), choice("15.4.2", "Высокая"), choice("15.4.3", "Низкая"),
+    ]),
+    group("15.5", "Структура", [
+      choice("15.5.1", "Однородная"),
+      choice("15.5.2", "Неоднородная", [
+        choice("15.5.2.1", "С участками затемнения"),
+        choice("15.5.2.2", "С участками минерализации"),
+        choice("15.5.2.3", "Другое", [requiredLongText("15.5.2.3.text", "Описание структуры")]),
+      ]),
+    ]),
+    group("15.6", "Патологии", [
+      choice("15.6.1", "Не выявлены"),
+      choice("15.6.2", "Выявлены", [
+        choice("15.6.2.1", "Минерализация лоханки"),
+        choice("15.6.2.2", "Нефролит"),
+        choice("15.6.2.3", "Другое", [requiredLongText("15.6.2.3.text", "Описание патологий")]),
+      ]),
+    ]),
+  ]),
+  group("16", "Мочеточники", [
+    choice("16.0.1", "Визуализируются"), choice("16.0.2", "Не визуализируются"),
+  ]),
+  group("17", "Мочевой пузырь", [
+    group("17.1", "Наполнение", [
+      choice("17.1.1", "Умеренное"), choice("17.1.2", "Слабое"), choice("17.1.3", "Чрезмерное"),
+    ]),
+    group("17.2", "Форма", [
+      choice("17.2.1", "Округлая"), choice("17.2.2", "Овальная"), choice("17.2.3", "Неправильная"),
+    ]),
+    group("17.3", "Плотность", [
+      choice("17.3.1", "Средняя"), choice("17.3.2", "Высокая"), choice("17.3.3", "Низкая"),
+    ]),
+    group("17.4", "Структура", [choice("17.4.1", "Однородная"), choice("17.4.2", "Неоднородная")]),
+    group("17.5", "Положение", [
+      choice("17.5.1", "Типичное"),
+      choice("17.5.2", "Выявлена дислокация", [requiredLongText("17.5.2.text", "Описание дислокации")]),
+    ]),
+    group("17.6", "Патологии", [
+      choice("17.6.1", "Не выявлены"),
+      choice("17.6.2", "Выявлены", [
+        choice("17.6.2.1", "Единичный уролит"),
+        choice("17.6.2.2", "Множественные уролиты"),
+        choice("17.6.2.3", "Конгломерат уролитов"),
+        choice("17.6.2.4", "Другое", [requiredLongText("17.6.2.4.text", "Описание патологий")]),
+      ]),
+    ]),
+  ]),
+  group("18", "Уретра", [
+    choice("18.0.1", "Не визуализируется"), choice("18.0.2", "Визуализируется"),
+    longText("18.1", "Другое"),
+  ]),
+  group("19", "Ретроперитонеальное пространство", [
+    group("19.1", "Патологии", [
+      choice("19.1.1", "Не выявлены"),
+      choice("19.1.2", "Выявлены", [requiredLongText("19.1.2.text", "Описание патологий")]),
+    ]),
+  ]),
+  group("20", "Желудок", [
+    group("20.1", "Наполнение", [
+      choice("20.1.1", "Не наполнен"), choice("20.1.2", "Умеренно наполнен"),
+      choice("20.1.3", "Значимо наполнен"), choice("20.1.4", "Раздут"),
+    ]),
+    group("20.2", "Положение", [
+      choice("20.2.1", "Правильное"), choice("20.2.2", "Неправильное"),
+      choice("20.2.3", "Выявлена дислокация", [requiredLongText("20.2.3.1", "Описание дислокации")]),
+    ]),
+    group("20.3", "Ось", [
+      choice("20.3.1", "Сохранена"), choice("20.3.2", "Отсутствует"), choice("20.3.3", "Отклонена"),
+    ]),
+    group("20.4", "Патологии", [
+      choice("20.4.1", "Не выявлены"),
+      choice("20.4.2", "Выявлены", [requiredLongText("20.4.2.text", "Описание патологий")]),
+    ]),
+  ]),
+  group("21", "Тонкий отдел кишечника", [
+    group("21.1", "Положение", [
+      choice("21.1.1", "Правильное"), choice("21.1.2", "Неправильное"),
+      choice("21.1.3", "Выявлена дислокация", [requiredLongText("21.1.3.1", "Описание дислокации")]),
+    ]),
+    group("21.2", "Просвет", [
+      choice("21.2.1", "Не расширен"), choice("21.2.2", "Расширен на всём протяжении"),
+      choice("21.2.3", "Расширен локально"),
+    ]),
+    group("21.3", "Содержимое", [
+      choice("21.3.1", "Не визуализируется"),
+      choice("21.3.2", "Визуализируется", [
+        multipleGroup("21.3.2.contents", "Содержимое тонкого кишечника", [
+          choice("21.3.2.1", "Жидкость"), choice("21.3.2.2", "Газ"),
+          choice("21.3.2.3", "Контрастное вещество"), choice("21.3.2.4", "Линейный инородный предмет"),
+          choice("21.3.2.5", "Инородный предмет"),
+          choice("21.3.2.6", "Другое", [requiredLongText("21.3.2.6.text", "Описание содержимого")]),
+        ]),
+      ]),
+    ]),
+    group("21.4", "Патологии", [
+      choice("21.4.1", "Не выявлены"),
+      choice("21.4.2", "Выявлены", [requiredLongText("21.4.2.text", "Описание патологий")]),
+    ]),
+  ]),
+  group("22", "Толстый отдел кишечника", [
+    group("22.1", "Положение", [
+      choice("22.1.1", "Правильное"), choice("22.1.2", "Неправильное"),
+      choice("22.1.3", "Выявлена дислокация", [requiredLongText("22.1.3.1", "Описание дислокации")]),
+    ]),
+    group("22.2", "Просвет", [
+      choice("22.2.1", "Не расширен"), choice("22.2.2", "Расширен на всём протяжении"),
+      choice("22.2.3", "Расширен локально"), choice("22.2.4", "Значимо расширен каловыми массами"),
+    ]),
+    group("22.3", "Содержимое", [
+      choice("22.3.1", "Не визуализируется"),
+      choice("22.3.2", "Визуализируется", [
+        multipleGroup("22.3.2.contents", "Содержимое толстого кишечника", [
+          choice("22.3.2.1", "Жидкость"), choice("22.3.2.2", "Газ"),
+          choice("22.3.2.3", "Каловые массы"), choice("22.3.2.4", "Контрастное вещество"),
+          choice("22.3.2.5", "Линейный инородный предмет"), choice("22.3.2.6", "Инородный предмет"),
+          choice("22.3.2.7", "Другое", [requiredLongText("22.3.2.7.text", "Описание содержимого")]),
+        ]),
+      ]),
+    ]),
+    group("22.4", "Патологии", [
+      choice("22.4.1", "Не выявлены"),
+      choice("22.4.2", "Выявлены", [requiredLongText("22.4.2.text", "Описание патологий")]),
+    ]),
+  ]),
+  group("23", "Репродуктивная система", [
+    group("23.1", "Матка", [
+      choice("23.1.0.1", "Визуализируется", [
+        group("23.1.1", "Просвет", [choice("23.1.1.1", "Расширен"), choice("23.1.1.2", "Не расширен")]),
+      ]),
+      choice("23.1.0.2", "Не визуализируется"),
+    ]),
+    group("23.2", "Предстательная железа", [
+      choice("23.2.1", "Визуализируется"), choice("23.2.2", "Не визуализируется"),
+    ]),
+    group("23.3", "Половой член", [
+      group("23.3.1", "Os penis", [
+        choice("23.3.1.1", "Не визуализируется"),
+        choice("23.3.1.2", "Визуализируется", [
+          inlineSelectionSetGroup("23.3.1.2.characteristics", "Характеристики Os penis", [
+            choice("23.3.1.3", "Чётко"), choice("23.3.1.4", "Нечётко"), choice("23.3.1.5", "Имеет перелом"),
+          ], [{
+            key: "definition",
+            name: "Чёткость",
+            choiceIds: [id("23.3.1.3"), id("23.3.1.4")],
+          }, {
+            key: "fracture",
+            name: "Перелом",
+            choiceIds: [id("23.3.1.5")],
+            selectionMode: "multiple",
+          }]),
+        ]),
+      ]),
+      group("23.3.2", "Мягкие ткани", [
+        choice("23.3.2.1", "Без патологий"),
+        choice("23.3.2.2", "Имеют патологии", [requiredLongText("23.3.2.2.1", "Описание патологий")]),
+      ]),
+    ]),
+    longText("23.4", "Дополнительно"),
+  ]),
+  group("24", "Перитонеальная полость", [
+    group("24.1", "Жидкость", [
+      choice("24.1.1", "Не визуализируется"),
+      choice("24.1.2", "Визуализируется", [
+        choice("24.1.2.1", "Незначительно"), choice("24.1.2.2", "Значительно"),
+      ]),
+    ]),
+    group("24.2", "Газ", [
+      choice("24.2.1", "Не визуализируется"),
+      choice("24.2.2", "Визуализируется", [
+        choice("24.2.2.1", "Незначительно"), choice("24.2.2.2", "Значительно"),
+      ]),
+    ]),
+    longText("24.3", "Другое"),
+  ]),
+  longText("25", "Комментарии"),
+  longText("26", "Заключение"),
+];

--- a/tests/instrumental.spec.ts
+++ b/tests/instrumental.spec.ts
@@ -18,6 +18,8 @@ const prefix = "instrumental.finding.ultrasound-abdomen";
 const id = (code: string) => `${prefix}.${code}`;
 const xrayPrefix = "instrumental.finding.xray-thorax";
 const xrayId = (code: string) => `${xrayPrefix}.${code}`;
+const abdomenXrayPrefix = "instrumental.finding.xray-abdomen";
+const abdomenXrayId = (code: string) => `${abdomenXrayPrefix}.${code}`;
 const value = (id: string, children: InstrumentalFindingValue[] = [], text?: string): InstrumentalFindingValue => ({
   findingId: id,
   findingName: "forged",
@@ -30,6 +32,7 @@ describe("instrumental study contracts", () => {
     expect(INSTRUMENTAL_STUDY_CATALOG.map((study) => [study.name, study.mode])).toEqual([
       ["УЗИ органов брюшной полости", "tree"],
       ["Рентгенография грудной полости", "tree"],
+      ["Рентгенография брюшной полости", "tree"],
     ]);
     const roots = INSTRUMENTAL_STUDY_CATALOG[0]!.findings;
     expect(roots).toHaveLength(19);
@@ -52,6 +55,177 @@ describe("instrumental study contracts", () => {
       "9.2.1", "9.3.5.2.3", "10.0", "10.5", "11.3.7", "11.4", "16.1.3", "16.2.3", "16.3.3",
     ]);
     expect(integers.every((item) => item.unit === "мм" && !item.name.includes("мм"))).toBe(true);
+  });
+
+  it("defines the complete abdominal X-ray hierarchy and choice matrix", () => {
+    const xray = INSTRUMENTAL_STUDY_CATALOG.find((study) => study.id === "instrumental.study.xray-abdomen")!;
+    expect(xray.findings).toHaveLength(26);
+    expect(xray.findings.map((item) => item.id.replace(`${abdomenXrayPrefix}.`, ""))).toEqual([
+      "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13",
+      "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26",
+    ]);
+    expect(xray.findings.map((item) => item.name)).toEqual([
+      "Выполненные проекции", "Качество рентгенограмм", "Режим экспозиции", "Область интересов",
+      "Охват области интересов", "Мягкие ткани", "Упитанность", "Костно-суставной аппарат",
+      "Купол диафрагмы", "Серозная дифференциация", "Брюшная стенка", "Печень", "Селезёнка",
+      "Область поджелудочной железы", "Почки", "Мочеточники", "Мочевой пузырь", "Уретра",
+      "Ретроперитонеальное пространство", "Желудок", "Тонкий отдел кишечника",
+      "Толстый отдел кишечника", "Репродуктивная система", "Перитонеальная полость", "Комментарии", "Заключение",
+    ]);
+
+    const multiple: InstrumentalFindingCatalogItem[] = [];
+    const sets: InstrumentalFindingCatalogItem[] = [];
+    const required: InstrumentalFindingCatalogItem[] = [];
+    const visit = (items: readonly InstrumentalFindingCatalogItem[]) => items.forEach((item) => {
+      if (item.selectionMode === "multiple") multiple.push(item);
+      if (item.selectionSets?.length) sets.push(item);
+      if (item.required) required.push(item);
+      visit(item.children);
+    });
+    visit(xray.findings);
+    expect(multiple.map((item) => item.id)).toEqual([
+      abdomenXrayId("1.0"), abdomenXrayId("8.0.3.findings"), abdomenXrayId("21.3.2.contents"),
+      abdomenXrayId("22.3.2.contents"), abdomenXrayId("23.3.1.2.characteristics"),
+    ]);
+    expect(sets.map((item) => [item.id, item.selectionSets?.map((set) => [set.key, set.selectionMode ?? "single"])])).toEqual([
+      [abdomenXrayId("9.0"), [["regularity", "single"], ["definition", "single"], ["projection", "single"]]],
+      [abdomenXrayId("11.0"), [["regularity", "single"], ["definition", "single"]]],
+      [abdomenXrayId("12.3"), [["definition", "single"], ["rib-arch-position", "single"]]],
+      [abdomenXrayId("13.1"), [["size", "single"], ["homogeneity", "single"]]],
+      [abdomenXrayId("23.3.1.2.characteristics"), [["definition", "single"], ["fracture", "multiple"]]],
+    ]);
+    expect(instrumentalFindingById(abdomenXrayId("6.0.2.4"))?.name).toBe("Другое");
+    expect(instrumentalFindingById(abdomenXrayId("16.0.1"))?.name).toBe("Визуализируются");
+    expect(instrumentalFindingById(abdomenXrayId("17.2.1"))?.name).toBe("Округлая");
+    expect(instrumentalFindingById(abdomenXrayId("20.2.3.1"))).toMatchObject({
+      name: "Описание дислокации", kind: "long-text", required: true,
+    });
+    expect(instrumentalFindingById(abdomenXrayId("23.1.0.1"))?.children[0]?.id).toBe(abdomenXrayId("23.1.1"));
+    expect(required.every((item) => item.kind === "short-text" || item.kind === "long-text")).toBe(true);
+    expect(instrumentalFindingById(abdomenXrayId("9.0.5.intercostal"))).toMatchObject({
+      kind: "short-text", required: true,
+    });
+    expect(instrumentalFindingById(abdomenXrayId("8.0.3.2.text"))).toMatchObject({
+      kind: "long-text", required: true,
+    });
+  });
+
+  it("normalizes every independent abdominal X-ray checkbox group in catalog order", () => {
+    const normalized = normalizeInstrumentalTestsValue({ studies: [{
+      ...base,
+      typeId: "instrumental.study.xray-abdomen",
+      findings: [
+        value(abdomenXrayId("22"), [value(abdomenXrayId("22.3"), [value(abdomenXrayId("22.3.2"), [
+          value(abdomenXrayId("22.3.2.contents"), [
+            value(abdomenXrayId("22.3.2.7"), [value(abdomenXrayId("22.3.2.7.text"), [], " Другое содержимое ")]),
+            value(abdomenXrayId("22.3.2.2")), value(abdomenXrayId("22.3.2.1")),
+          ]),
+        ])])]),
+        value(abdomenXrayId("1"), [value(abdomenXrayId("1.0"), [
+          value(abdomenXrayId("1.0.4")), value(abdomenXrayId("1.0.1")),
+          value(abdomenXrayId("1.0.3")), value(abdomenXrayId("1.0.2")),
+        ])]),
+        value(abdomenXrayId("21"), [value(abdomenXrayId("21.3"), [value(abdomenXrayId("21.3.2"), [
+          value(abdomenXrayId("21.3.2.contents"), [
+            value(abdomenXrayId("21.3.2.6"), [value(abdomenXrayId("21.3.2.6.text"), [], " Иное ")]),
+            value(abdomenXrayId("21.3.2.1")), value(abdomenXrayId("21.3.2.2")),
+          ]),
+        ])])]),
+        value(abdomenXrayId("8"), [value(abdomenXrayId("8.0.3"), [
+          value(abdomenXrayId("8.0.3.findings"), [
+            value(abdomenXrayId("8.0.3.5"), [value(abdomenXrayId("8.0.3.5.text"), [], " Иная патология ")]),
+            value(abdomenXrayId("8.0.3.2"), [value(abdomenXrayId("8.0.3.2.text"), [], " Перелом таза ")]),
+            value(abdomenXrayId("8.0.3.1")),
+          ]),
+        ])]),
+      ],
+    }] }, "2026-08-15").studies[0]!;
+    if (normalized.mode !== "tree") throw new Error("Expected tree study");
+    expect(normalized).toMatchObject({
+      typeId: "instrumental.study.xray-abdomen",
+      typeName: "Рентгенография брюшной полости",
+    });
+    expect(normalized.findings.map((item) => item.findingId)).toEqual([
+      abdomenXrayId("1"), abdomenXrayId("8"), abdomenXrayId("21"), abdomenXrayId("22"),
+    ]);
+    expect(normalized.findings[0]?.children[0]?.children.map((item) => item.findingId)).toEqual([
+      abdomenXrayId("1.0.1"), abdomenXrayId("1.0.2"), abdomenXrayId("1.0.3"), abdomenXrayId("1.0.4"),
+    ]);
+    expect(normalized.findings[1]?.children[0]?.children[0]?.children.map((item) => item.findingId)).toEqual([
+      abdomenXrayId("8.0.3.1"), abdomenXrayId("8.0.3.2"), abdomenXrayId("8.0.3.5"),
+    ]);
+    expect(normalized.findings[1]?.children[0]?.children[0]?.children[1]?.children[0]).toMatchObject({
+      findingName: "Описание перелома", value: "Перелом таза",
+    });
+  });
+
+  it("enforces each abdominal X-ray composite choice set independently", () => {
+    const invalidCases: [string, InstrumentalFindingValue, string][] = [
+      ["diaphragm regularity", value(abdomenXrayId("9"), [value(abdomenXrayId("9.0"), [
+        value(abdomenXrayId("9.0.1")), value(abdomenXrayId("9.0.2")), value(abdomenXrayId("9.0.3")),
+      ])]), "Ровность купола"],
+      ["abdominal wall definition", value(abdomenXrayId("11"), [value(abdomenXrayId("11.0"), [
+        value(abdomenXrayId("11.0.1")), value(abdomenXrayId("11.0.3")), value(abdomenXrayId("11.0.4")),
+      ])]), "Чёткость стенки"],
+      ["liver rib arch position", value(abdomenXrayId("12"), [value(abdomenXrayId("12.3"), [
+        value(abdomenXrayId("12.3.1")), value(abdomenXrayId("12.3.3")), value(abdomenXrayId("12.3.4")),
+      ])]), "Положение относительно рёберной дуги"],
+      ["spleen homogeneity", value(abdomenXrayId("13"), [value(abdomenXrayId("13.1"), [
+        value(abdomenXrayId("13.1.1")), value(abdomenXrayId("13.1.3")), value(abdomenXrayId("13.1.4")),
+      ])]), "Однородность тени"],
+      ["Os penis definition", value(abdomenXrayId("23"), [value(abdomenXrayId("23.3"), [
+        value(abdomenXrayId("23.3.1"), [value(abdomenXrayId("23.3.1.2"), [
+          value(abdomenXrayId("23.3.1.2.characteristics"), [
+            value(abdomenXrayId("23.3.1.3")), value(abdomenXrayId("23.3.1.4")), value(abdomenXrayId("23.3.1.5")),
+          ]),
+        ])]),
+      ])]), "Чёткость"],
+    ];
+    for (const [, finding, error] of invalidCases) {
+      expect(() => normalizeInstrumentalTestsValue({ studies: [{
+        ...base, typeId: "instrumental.study.xray-abdomen", findings: [finding],
+      }] }, "2026-08-15")).toThrow(error);
+    }
+
+    const normalized = normalizeInstrumentalTestsValue({ studies: [{
+      ...base,
+      typeId: "instrumental.study.xray-abdomen",
+      findings: [
+        value(abdomenXrayId("9"), [value(abdomenXrayId("9.0"), [
+          value(abdomenXrayId("9.0.2")), value(abdomenXrayId("9.0.3")),
+        ])]),
+        value(abdomenXrayId("11"), [value(abdomenXrayId("11.0"), [
+          value(abdomenXrayId("11.0.2")), value(abdomenXrayId("11.0.3")),
+        ])]),
+        value(abdomenXrayId("12"), [value(abdomenXrayId("12.3"), [
+          value(abdomenXrayId("12.3.2")), value(abdomenXrayId("12.3.6")),
+        ])]),
+        value(abdomenXrayId("13"), [value(abdomenXrayId("13.1"), [
+          value(abdomenXrayId("13.1.2")), value(abdomenXrayId("13.1.4")),
+        ])]),
+        value(abdomenXrayId("23"), [value(abdomenXrayId("23.3"), [value(abdomenXrayId("23.3.1"), [
+          value(abdomenXrayId("23.3.1.2"), [value(abdomenXrayId("23.3.1.2.characteristics"), [
+            value(abdomenXrayId("23.3.1.4")), value(abdomenXrayId("23.3.1.5")),
+          ])]),
+        ])])]),
+      ],
+    }] }, "2026-08-15").studies[0]!;
+    expect(normalized.mode === "tree" ? normalized.findings : []).toHaveLength(5);
+  });
+
+  it("requires active abdominal X-ray continuations and rejects hidden branch data", () => {
+    expect(() => normalizeInstrumentalTestsValue({ studies: [{
+      ...base,
+      typeId: "instrumental.study.xray-abdomen",
+      findings: [value(abdomenXrayId("9"), [value(abdomenXrayId("9.0"), [value(abdomenXrayId("9.0.5"))])])],
+    }] }, "2026-08-15")).toThrow("Межреберье на LL-проекции");
+    expect(() => normalizeInstrumentalTestsValue({ studies: [{
+      ...base,
+      typeId: "instrumental.study.xray-abdomen",
+      findings: [value(abdomenXrayId("23"), [value(abdomenXrayId("23.1"), [
+        value(abdomenXrayId("23.1.0.2"), [value(abdomenXrayId("23.1.1"), [value(abdomenXrayId("23.1.1.1"))])]),
+      ])])],
+    }] }, "2026-08-15")).toThrow("структура");
   });
 
   it("defines the complete thoracic X-ray hierarchy, selection modes, conflicts, and required continuations", () => {

--- a/tests/instrumentalTestsEditor.spec.ts
+++ b/tests/instrumentalTestsEditor.spec.ts
@@ -18,6 +18,8 @@ const prefix = "instrumental.finding.ultrasound-abdomen";
 const id = (code: string) => `${prefix}.${code}`;
 const xrayPrefix = "instrumental.finding.xray-thorax";
 const xrayId = (code: string) => `${xrayPrefix}.${code}`;
+const abdomenXrayPrefix = "instrumental.finding.xray-abdomen";
+const abdomenXrayId = (code: string) => `${abdomenXrayPrefix}.${code}`;
 
 function mountEditor(initial: InstrumentalTestsSectionValue = { studies: [] }, errors?: object) {
   let current = initial;
@@ -888,5 +890,104 @@ describe("InstrumentalTestsEditor", () => {
     await flushPromises();
     expect(current().studies).toHaveLength(0);
     expect(wrapper.find('[role="alertdialog"]').exists()).toBe(false);
+  });
+
+  it("edits abdominal X-ray multi-selects, composite sets, and conditional branches", async () => {
+    const { wrapper, current } = mountEditor();
+    const checkbox = (panel: DOMWrapper<Element>, name: string) => panel.findAll("label.check-row")
+      .find((label) => label.text() === name)!.get<HTMLInputElement>('input[type="checkbox"]');
+    const panel = (name: string) => wrapper.findAll("fieldset")
+      .find((candidate) => candidate.get("legend").text() === name)!;
+
+    await chooseType(wrapper, "instrumental.study.xray-abdomen");
+    expect(current().studies[0]).toMatchObject({
+      typeId: "instrumental.study.xray-abdomen",
+      typeName: "Рентгенография брюшной полости",
+      mode: "tree",
+    });
+
+    await addFinding(wrapper, abdomenXrayId("1"));
+    await checkbox(panel("Проекции"), "Левая латеролатеральная").setValue(true);
+    await checkbox(panel("Проекции"), "Правая латеролатеральная").setValue(true);
+    await checkbox(panel("Проекции"), "Вентродорсальная").setValue(true);
+    expect(current().studies[0]?.mode === "tree"
+      ? current().studies[0].findings[0]?.children[0]?.children.map((item) => item.findingId)
+      : []).toEqual([abdomenXrayId("1.0.1"), abdomenXrayId("1.0.2"), abdomenXrayId("1.0.3")]);
+
+    await addFinding(wrapper, abdomenXrayId("8"));
+    await selectChoice(wrapper, abdomenXrayId("8.0.3"));
+    const pathologyPanel = panel("Признаки патологий");
+    await checkbox(pathologyPanel, "Остеофиты").setValue(true);
+    await checkbox(pathologyPanel, "Перелом").setValue(true);
+    const fracture = wrapper.get<HTMLTextAreaElement>('textarea[aria-label="Описание перелома"]');
+    expect(fracture.attributes("rows")).toBe("2");
+    expect(fracture.classes()).toContain("medical-card-comment");
+    await fracture.setValue("Перелом таза");
+
+    await addFinding(wrapper, abdomenXrayId("9"));
+    await addFinding(wrapper, abdomenXrayId("9.0"));
+    const diaphragm = wrapper.get(`[data-finding-id="${abdomenXrayId("9.0")}"]`);
+    const regularity = diaphragm.get<HTMLSelectElement>('select[aria-label="Ровность купола"]');
+    const definition = diaphragm.get<HTMLSelectElement>('select[aria-label="Чёткость купола"]');
+    const projection = diaphragm.get<HTMLSelectElement>('select[aria-label="Проекция измерения"]');
+    await regularity.setValue(abdomenXrayId("9.0.1"));
+    await definition.setValue(abdomenXrayId("9.0.3"));
+    await projection.setValue(abdomenXrayId("9.0.5"));
+    await diaphragm.get('input[aria-label="Межреберье на LL-проекции"]').setValue("7");
+    await regularity.setValue(abdomenXrayId("9.0.2"));
+    expect(definition.element.value).toBe(abdomenXrayId("9.0.3"));
+    expect(projection.element.value).toBe(abdomenXrayId("9.0.5"));
+    await projection.setValue(abdomenXrayId("9.0.6"));
+    expect(diaphragm.find('input[aria-label="Межреберье на LL-проекции"]').exists()).toBe(false);
+    expect(diaphragm.get<HTMLInputElement>('input[aria-label="Межреберье на VD-проекции"]').element.value).toBe("");
+
+    await addFinding(wrapper, abdomenXrayId("21"));
+    await addFinding(wrapper, abdomenXrayId("21.3"));
+    await selectChoice(wrapper, abdomenXrayId("21.3.2"));
+    const smallIntestine = panel("Содержимое тонкого кишечника");
+    await checkbox(smallIntestine, "Жидкость").setValue(true);
+    await checkbox(smallIntestine, "Газ").setValue(true);
+    await checkbox(smallIntestine, "Другое").setValue(true);
+    await wrapper.get('textarea[aria-label="Описание содержимого"]').setValue("Непереваренные массы");
+    expect(checkbox(smallIntestine, "Жидкость").element.checked).toBe(true);
+    expect(checkbox(smallIntestine, "Газ").element.checked).toBe(true);
+
+    await addFinding(wrapper, abdomenXrayId("23"));
+    await addFinding(wrapper, abdomenXrayId("23.1"));
+    await selectChoice(wrapper, abdomenXrayId("23.1.0.1"));
+    await addFinding(wrapper, abdomenXrayId("23.1.1"));
+    await selectChoice(wrapper, abdomenXrayId("23.1.1.1"));
+    await selectChoice(wrapper, abdomenXrayId("23.1.0.2"));
+    const reproductive = current().studies[0]?.mode === "tree"
+      ? current().studies[0].findings.find((finding) => finding.findingId === abdomenXrayId("23"))
+      : undefined;
+    expect(reproductive?.children.find((finding) => finding.findingId === abdomenXrayId("23.1"))?.children)
+      .toEqual([expect.objectContaining({ findingId: abdomenXrayId("23.1.0.2"), children: [] })]);
+
+    await addFinding(wrapper, abdomenXrayId("23.3"));
+    await addFinding(wrapper, abdomenXrayId("23.3.1"));
+    await selectChoice(wrapper, abdomenXrayId("23.3.1.2"));
+    const osPenis = wrapper.get(`[data-finding-id="${abdomenXrayId("23.3.1.2.characteristics")}"]`);
+    const clarity = osPenis.get<HTMLSelectElement>('select[aria-label="Чёткость"]');
+    const fractureCheckbox = checkbox(panel("Перелом"), "Имеет перелом");
+    await clarity.setValue(abdomenXrayId("23.3.1.3"));
+    await fractureCheckbox.setValue(true);
+    expect(clarity.element.value).toBe(abdomenXrayId("23.3.1.3"));
+    expect(fractureCheckbox.element.checked).toBe(true);
+    expect(osPenis.get(".instrumental-finding-content").attributes("data-hierarchy-depth")).toBe("3");
+
+    await selectChoice(wrapper, abdomenXrayId("23.3.1.1"));
+    expect(wrapper.find(`[data-finding-id="${abdomenXrayId("23.3.1.2.characteristics")}"]`).exists()).toBe(false);
+    const osPenisValue = reproductive?.children.find((finding) => finding.findingId === abdomenXrayId("23.3"))
+      ?.children.find((finding) => finding.findingId === abdomenXrayId("23.3.1"));
+    expect(osPenisValue?.children).toEqual([
+      expect.objectContaining({ findingId: abdomenXrayId("23.3.1.1"), children: [] }),
+    ]);
+
+    const reopened = mountEditor(current());
+    expect(reopened.wrapper.get('select[aria-label="Значение показателя «Os penis»"]').element)
+      .toHaveProperty("value", abdomenXrayId("23.3.1.1"));
+    expect(reopened.wrapper.get('textarea[aria-label="Описание перелома"]').element)
+      .toHaveProperty("value", "Перелом таза");
   });
 });

--- a/tests/instrumentalTestsValidation.spec.ts
+++ b/tests/instrumentalTestsValidation.spec.ts
@@ -11,8 +11,20 @@ const prefix = "instrumental.finding.ultrasound-abdomen";
 const id = (code: string) => `${prefix}.${code}`;
 const xrayPrefix = "instrumental.finding.xray-thorax";
 const xrayId = (code: string) => `${xrayPrefix}.${code}`;
+const abdomenXrayPrefix = "instrumental.finding.xray-abdomen";
+const abdomenXrayId = (code: string) => `${abdomenXrayPrefix}.${code}`;
 const finding = (code: string, children: InstrumentalFindingValue[] = [], value?: string): InstrumentalFindingValue => ({
   findingId: id(code),
+  findingName: "forged",
+  ...(value === undefined ? {} : { value }),
+  children,
+});
+const abdomenXrayFinding = (
+  code: string,
+  children: InstrumentalFindingValue[] = [],
+  value?: string,
+): InstrumentalFindingValue => ({
+  findingId: abdomenXrayId(code),
   findingName: "forged",
   ...(value === undefined ? {} : { value }),
   children,
@@ -125,6 +137,90 @@ describe("instrumental draft validation", () => {
     }));
     expect(parseInstrumentalTestsDraft(lungDraft(normalWithPattern), "2026-08-15").errors.studies[0]?.findings)
       .toEqual({ [xrayId("17.3")]: "Для показателя «Лёгочный рисунок» выбраны несовместимые варианты." });
+  });
+
+  it("places abdominal X-ray composite-set and continuation errors beside their controls", () => {
+    const cases: [InstrumentalFindingValue, string, string][] = [
+      [abdomenXrayFinding("9", [abdomenXrayFinding("9.0", [
+        abdomenXrayFinding("9.0.1"), abdomenXrayFinding("9.0.2"),
+      ])]), `${abdomenXrayId("9.0")}:regularity`, "Ровность купола"],
+      [abdomenXrayFinding("11", [abdomenXrayFinding("11.0", [
+        abdomenXrayFinding("11.0.3"), abdomenXrayFinding("11.0.4"),
+      ])]), `${abdomenXrayId("11.0")}:definition`, "Чёткость стенки"],
+      [abdomenXrayFinding("12", [abdomenXrayFinding("12.3", [
+        abdomenXrayFinding("12.3.3"), abdomenXrayFinding("12.3.4"),
+      ])]), `${abdomenXrayId("12.3")}:rib-arch-position`, "Положение относительно рёберной дуги"],
+      [abdomenXrayFinding("13", [abdomenXrayFinding("13.1", [
+        abdomenXrayFinding("13.1.3"), abdomenXrayFinding("13.1.4"),
+      ])]), `${abdomenXrayId("13.1")}:homogeneity`, "Однородность тени"],
+      [abdomenXrayFinding("23", [abdomenXrayFinding("23.3", [abdomenXrayFinding("23.3.1", [
+        abdomenXrayFinding("23.3.1.2", [abdomenXrayFinding("23.3.1.2.characteristics", [
+          abdomenXrayFinding("23.3.1.3"), abdomenXrayFinding("23.3.1.4"),
+        ])]),
+      ])])]), `${abdomenXrayId("23.3.1.2.characteristics")}:definition`, "Чёткость"],
+    ];
+    for (const [root, key, name] of cases) {
+      const result = parseInstrumentalTestsDraft({ studies: [{
+        ...base,
+        typeId: "instrumental.study.xray-abdomen",
+        typeName: "Рентгенография брюшной полости",
+        mode: "tree",
+        findings: [root],
+      }] }, "2026-08-15");
+      expect(result.errors.studies[0]?.findings).toEqual({
+        [key]: `Для характеристики «${name}» можно выбрать не более одного значения.`,
+      });
+    }
+
+    const continuations = parseInstrumentalTestsDraft({ studies: [{
+      ...base,
+      typeId: "instrumental.study.xray-abdomen",
+      typeName: "Рентгенография брюшной полости",
+      mode: "tree",
+      findings: [
+        abdomenXrayFinding("8", [abdomenXrayFinding("8.0.3", [
+          abdomenXrayFinding("8.0.3.findings", [abdomenXrayFinding("8.0.3.2")]),
+        ])]),
+        abdomenXrayFinding("9", [abdomenXrayFinding("9.0", [abdomenXrayFinding("9.0.5")])]),
+      ],
+    }] }, "2026-08-15");
+    expect(continuations.errors.studies[0]?.findings).toEqual({
+      [abdomenXrayId("8.0.3.2.text")]: "Заполните поле «Описание перелома».",
+      [abdomenXrayId("9.0.5.intercostal")]: "Заполните поле «Межреберье на LL-проекции».",
+    });
+  });
+
+  it("accepts one value from every abdominal X-ray composite set", () => {
+    const result = parseInstrumentalTestsDraft({ studies: [{
+      ...base,
+      typeId: "instrumental.study.xray-abdomen",
+      typeName: "forged",
+      mode: "tree",
+      findings: [
+        abdomenXrayFinding("9", [abdomenXrayFinding("9.0", [
+          abdomenXrayFinding("9.0.1"), abdomenXrayFinding("9.0.3"),
+        ])]),
+        abdomenXrayFinding("11", [abdomenXrayFinding("11.0", [
+          abdomenXrayFinding("11.0.2"), abdomenXrayFinding("11.0.4"),
+        ])]),
+        abdomenXrayFinding("12", [abdomenXrayFinding("12.3", [
+          abdomenXrayFinding("12.3.1"), abdomenXrayFinding("12.3.5"),
+        ])]),
+        abdomenXrayFinding("13", [abdomenXrayFinding("13.1", [
+          abdomenXrayFinding("13.1.2"), abdomenXrayFinding("13.1.3"),
+        ])]),
+        abdomenXrayFinding("23", [abdomenXrayFinding("23.3", [abdomenXrayFinding("23.3.1", [
+          abdomenXrayFinding("23.3.1.2", [abdomenXrayFinding("23.3.1.2.characteristics", [
+            abdomenXrayFinding("23.3.1.3"), abdomenXrayFinding("23.3.1.5"),
+          ])]),
+        ])])]),
+      ],
+    }] }, "2026-08-15");
+    expect(result.errors.studies[0]?.findings).toEqual({});
+    expect(result.value?.studies[0]).toMatchObject({
+      typeId: "instrumental.study.xray-abdomen",
+      typeName: "Рентгенография брюшной полости",
+    });
   });
 
   it("places a separate inline error beside each missing prostate contour characteristic", () => {

--- a/tests/medicalEncounter.spec.ts
+++ b/tests/medicalEncounter.spec.ts
@@ -160,7 +160,7 @@ describe("medical encounter templates", () => {
     expect(sections["what-happened"].value.selectedIds).toEqual(["well.8", "well.9"]);
   });
 
-  it("indexes structured ultrasound and thoracic X-ray results", () => {
+  it("indexes structured ultrasound, thoracic X-ray, and abdominal X-ray results", () => {
     const tree = {
       studies: [{
         id: "123e4567-e89b-12d3-a456-426614174000",
@@ -191,6 +191,25 @@ describe("medical encounter templates", () => {
         children: [],
       }],
     }] })).toContain("Рентгенография грудной полости Заключение Очаговых изменений нет");
+    expect(sectionSearchText({ studies: [{
+      ...tree.studies[0],
+      typeId: "instrumental.study.xray-abdomen",
+      typeName: "Рентгенография брюшной полости",
+      mode: "tree",
+      comment: undefined,
+      findings: [{
+        findingId: "instrumental.finding.xray-abdomen.21",
+        findingName: "Тонкий отдел кишечника",
+        children: [],
+      }, {
+          findingId: "instrumental.finding.xray-abdomen.26",
+          findingName: "Заключение",
+          value: "Признаки кишечной непроходимости",
+          children: [],
+      }],
+    }] })).toContain(
+      "Рентгенография брюшной полости Тонкий отдел кишечника Заключение Признаки кишечной непроходимости",
+    );
   });
 
   it("defines, validates, and indexes the structured outcome template", () => {

--- a/tests/medicalRecordEntry.spec.ts
+++ b/tests/medicalRecordEntry.spec.ts
@@ -257,6 +257,95 @@ describe("MedicalRecordEntry", () => {
     expect(history.text()).toContain("Контроль");
   });
 
+  it("renders composite and multiple abdominal X-ray findings recursively", () => {
+    const wrapper = mount(MedicalRecordEntry, {
+      props: {
+        record: {
+          ...record,
+          sections: {
+            ...record.sections,
+            "instrumental-tests": {
+              kind: "instrumental-tests",
+              templateVersion: "instrumental-tests-v1",
+              value: { studies: [{
+                id: "123e4567-e89b-12d3-a456-426614174000",
+                date: "2026-07-21",
+                typeId: "instrumental.study.xray-abdomen",
+                typeName: "Рентгенография брюшной полости",
+                mode: "tree",
+                findings: [{
+                  findingId: "instrumental.finding.xray-abdomen.9",
+                  findingName: "Купол диафрагмы",
+                  children: [{
+                    findingId: "instrumental.finding.xray-abdomen.9.0",
+                    findingName: "Характеристики купола",
+                    children: [{
+                      findingId: "instrumental.finding.xray-abdomen.9.0.2",
+                      findingName: "Неровный",
+                      children: [],
+                    }, {
+                      findingId: "instrumental.finding.xray-abdomen.9.0.5",
+                      findingName: "На LL-проекции в области межреберья",
+                      children: [{
+                        findingId: "instrumental.finding.xray-abdomen.9.0.5.intercostal",
+                        findingName: "Межреберье на LL-проекции",
+                        value: "7",
+                        children: [],
+                      }],
+                    }],
+                  }],
+                }, {
+                  findingId: "instrumental.finding.xray-abdomen.21",
+                  findingName: "Тонкий отдел кишечника",
+                  children: [{
+                    findingId: "instrumental.finding.xray-abdomen.21.3",
+                    findingName: "Содержимое",
+                    children: [{
+                      findingId: "instrumental.finding.xray-abdomen.21.3.2",
+                      findingName: "Визуализируется",
+                      children: [{
+                        findingId: "instrumental.finding.xray-abdomen.21.3.2.contents",
+                        findingName: "Содержимое тонкого кишечника",
+                        children: [{
+                          findingId: "instrumental.finding.xray-abdomen.21.3.2.1",
+                          findingName: "Жидкость",
+                          children: [],
+                        }, {
+                          findingId: "instrumental.finding.xray-abdomen.21.3.2.2",
+                          findingName: "Газ",
+                          children: [],
+                        }],
+                      }],
+                    }],
+                  }],
+                }, {
+                  findingId: "instrumental.finding.xray-abdomen.26",
+                  findingName: "Заключение",
+                  value: "Признаки кишечной непроходимости",
+                  children: [],
+                }],
+              }] },
+              authorAccountId: "doctor-1",
+              authorDisplayName: "Вера Врач",
+              updatedAt: "2026-07-21T12:00:00.000Z",
+            },
+          },
+        },
+        mode: "details",
+        confirmed: false,
+        open: true,
+      },
+    });
+    const history = wrapper.get(".instrumental-history");
+    expect(history.text()).toContain("21.07.2026 · Рентгенография брюшной полости");
+    expect(history.text()).toContain("Неровный");
+    expect(history.text()).toContain("Межреберье на LL-проекции: 7");
+    expect(history.text()).toContain("Жидкость");
+    expect(history.text()).toContain("Газ");
+    expect(history.text()).toContain("Заключение: Признаки кишечной непроходимости");
+    expect(history.findAll(".instrumental-history-findings .instrumental-history-findings").length).toBeGreaterThanOrEqual(5);
+  });
+
   it("keeps the collapsed record header limited to date, author, and status", () => {
     const wrapper = mount(MedicalRecordEntry, {
       props: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,7 +20,7 @@ export default mergeConfig(
       coverage: {
         provider: 'v8',
         reporter: ['text', 'html', 'lcov', 'json'],
-        include: ['src/**/*.{ts,vue}', 'packages/contracts/src/{index,instrumental,xrayThorax}.ts'],
+        include: ['src/**/*.{ts,vue}', 'packages/contracts/src/{index,instrumental,xrayAbdomen,xrayThorax}.ts'],
         exclude: ['src/env.d.ts', '**/node_modules/**', '**/dist/**', '**/tests/**', '**/*.spec.ts']
       }
     },


### PR DESCRIPTION
## Summary

- add the 26-section structured `Рентгенография брюшной полости` catalog with stable abdominal X-ray IDs
- model the four independent checkbox groups, five composite choice ranges, conditional continuations, and automatic hidden-branch cleanup
- cover normalization, validation, editor interactions, API round trips, read-only history, search, responsive hierarchy, and end-to-end persistence
- include the existing 0.15.0 package/version changes

## Validation

- `npm run lint:check`
- `npm test` (505 tests)
- `npm run build`
- `npm run coverage` (new catalog: 100% statements/functions/branches)
- `npm run test:e2e:compose` (2 passed)

Closes #114